### PR TITLE
Add Ktor socket chat

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -30,4 +30,13 @@
     <string name="scan_qr">Scan QR</string>
     <string name="cancelled">Cancelled</string>
     <string name="camera_is_not_available">Camera is not available</string>
+    <string name="bind_host">Bind host</string>
+    <string name="port">Port</string>
+    <string name="start_server">Start server</string>
+    <string name="stop">Stop</string>
+    <string name="show_qr">Show QR</string>
+    <string name="remote_host">Remote host</string>
+    <string name="connect">Connect</string>
+    <string name="type_message">Type a message…</string>
+    <string name="send">Send</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
@@ -27,7 +27,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.softartdev.ktlan.connect.ConnectScreen
+import com.softartdev.ktlan.socket.SocketConnectScreen
 import com.softartdev.ktlan.isImeVisible
 import com.softartdev.ktlan.presentation.navigation.AppNavGraph
 import com.softartdev.ktlan.scan.ScanScreen
@@ -63,7 +63,7 @@ fun MainBottomNavScreen(
                 }
                 composable<AppNavGraph.BottomTab.Connect> {
                     selectedTab = AppNavGraph.BottomTab.Connect
-                    ConnectScreen(connectViewModel = koinViewModel())
+                    SocketConnectScreen(socketViewModel = koinViewModel())
                 }
                 composable<AppNavGraph.BottomTab.Settings> {
                     selectedTab = AppNavGraph.BottomTab.Settings

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
@@ -1,0 +1,217 @@
+package com.softartdev.ktlan.socket
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.material.icons.rounded.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.softartdev.ktlan.presentation.socket.SocketAction
+import com.softartdev.ktlan.presentation.socket.SocketResult
+import com.softartdev.ktlan.presentation.socket.SocketViewModel
+import ktlan.composeapp.generated.resources.Res
+import ktlan.composeapp.generated.resources.bind_host
+import ktlan.composeapp.generated.resources.connect
+import ktlan.composeapp.generated.resources.port
+import ktlan.composeapp.generated.resources.remote_host
+import ktlan.composeapp.generated.resources.scan_qr
+import ktlan.composeapp.generated.resources.send
+import ktlan.composeapp.generated.resources.show_qr
+import ktlan.composeapp.generated.resources.start_server
+import ktlan.composeapp.generated.resources.stop
+import ktlan.composeapp.generated.resources.type_message
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.ncgroup.kscan.BarcodeFormat
+import org.ncgroup.kscan.BarcodeResult
+import org.ncgroup.kscan.ScannerView
+import `in`.procyk.compose.camera.permission.CameraPermission
+import `in`.procyk.compose.camera.permission.CameraPermissionState
+import `in`.procyk.compose.camera.permission.rememberCameraPermissionState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SocketConnectScreen(socketViewModel: SocketViewModel = koinViewModel()) {
+    val result by socketViewModel.stateFlow.collectAsState()
+    LaunchedEffect(Unit) { socketViewModel.launch() }
+    SocketConnectContent(result, socketViewModel::onAction)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit) {
+    val listState = rememberLazyListState()
+    var showScanner by remember { mutableStateOf(false) }
+    val cameraPermissionState: CameraPermissionState = rememberCameraPermissionState()
+    val cancelledMessage = "Cancelled"
+    val cameraUnavailableMessage = "Camera unavailable"
+
+    Scaffold(topBar = { TopAppBar(title = { Text("LAN Chat") }) }) { padding ->
+        Column(
+            modifier = Modifier.padding(padding).fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            // Host section
+            Text(text = stringResource(Res.string.bind_host))
+            OutlinedTextField(
+                value = result.bindHost,
+                onValueChange = { onAction(SocketAction.SetBindHost(it)) },
+                label = { Text(stringResource(Res.string.bind_host)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = result.bindPort,
+                onValueChange = { onAction(SocketAction.SetBindPort(it)) },
+                label = { Text(stringResource(Res.string.port)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { onAction(SocketAction.StartServer(result.bindHost, result.bindPort)) }) {
+                    Text(stringResource(Res.string.start_server))
+                }
+                Button(onClick = { onAction(SocketAction.StopAll) }) {
+                    Icon(Icons.Outlined.Stop, contentDescription = null)
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(Res.string.stop))
+                }
+                Button(onClick = { onAction(SocketAction.ShowQrForServer) }) {
+                    Text(stringResource(Res.string.show_qr))
+                }
+            }
+
+            // Join section
+            Text(text = stringResource(Res.string.remote_host))
+            OutlinedTextField(
+                value = result.remoteHost,
+                onValueChange = { onAction(SocketAction.SetRemoteHost(it)) },
+                label = { Text(stringResource(Res.string.remote_host)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = result.remotePort,
+                onValueChange = { onAction(SocketAction.SetRemotePort(it)) },
+                label = { Text(stringResource(Res.string.port)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { onAction(SocketAction.Connect(result.remoteHost, result.remotePort)) }) {
+                    Text(stringResource(Res.string.connect))
+                }
+                Button(onClick = {
+                    when {
+                        cameraPermissionState.isAvailable -> when (cameraPermissionState.permission) {
+                            CameraPermission.Granted -> showScanner = true
+                            CameraPermission.Denied -> cameraPermissionState.launchRequest()
+                        }
+                        else -> onAction(SocketAction.EditDraft(cameraUnavailableMessage))
+                    }
+                }) {
+                    Icon(Icons.Default.QrCodeScanner, contentDescription = null)
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(Res.string.scan_qr))
+                }
+            }
+
+            // Messages
+            LazyColumn(modifier = Modifier.weight(1f), state = listState) {
+                items(result.messages) { message ->
+                    Row(modifier = Modifier.fillMaxWidth().padding(4.dp)) {
+                        Text(if (message.sender == com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local) "You:" else "Peer:")
+                        Spacer(Modifier.width(4.dp))
+                        Text(message.text)
+                    }
+                }
+            }
+
+            Row(verticalAlignment = Alignment.Bottom) {
+                val draft = result.draft
+                OutlinedTextField(
+                    modifier = Modifier.weight(1f),
+                    value = draft,
+                    onValueChange = { onAction(SocketAction.EditDraft(it)) },
+                    placeholder = { Text(stringResource(Res.string.type_message)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(onSend = { onAction(SocketAction.Send(draft)) })
+                )
+                FloatingActionButton(onClick = { onAction(SocketAction.Send(draft)) }) {
+                    Icon(Icons.Rounded.Send, contentDescription = null)
+                }
+            }
+        }
+    }
+
+    if (showScanner) {
+        ScannerView(
+            codeTypes = listOf(BarcodeFormat.FORMAT_QR_CODE),
+            result = { result ->
+                when (result) {
+                    is BarcodeResult.OnSuccess -> onAction(SocketAction.ApplyQrPayload(result.barcode.data))
+                    is BarcodeResult.OnFailed -> {}
+                    is BarcodeResult.OnCanceled -> onAction(SocketAction.EditDraft(cancelledMessage))
+                }
+                showScanner = false
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SocketConnectPreview() {
+    val sample = SocketResult(
+        connected = true,
+        messages = listOf(
+            com.softartdev.ktlan.domain.model.ChatMessage(
+                com.softartdev.ktlan.domain.model.ChatMessage.Sender.Remote,
+                "Hello",
+                0L
+            ),
+            com.softartdev.ktlan.domain.model.ChatMessage(
+                com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local,
+                "Hi!",
+                1L
+            )
+        )
+    )
+    SocketConnectContent(sample, onAction = {})
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging" }
+ktor-network = { module = "io.ktor:ktor-network" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }
 koin-core-viewmodel = { module = "io.insert-koin:koin-core-viewmodel" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.cio)
             implementation(libs.ktor.client.logging)
+            implementation(libs.ktor.network)
             implementation(libs.koin.core)
             implementation(libs.koin.core.viewmodel)
             implementation(libs.androidx.lifecycle.viewmodel)

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketEndpoint.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketEndpoint.kt
@@ -1,0 +1,9 @@
+package com.softartdev.ktlan.data.socket
+
+/**
+ * Endpoint information for socket connection.
+ */
+data class SocketEndpoint(
+    val host: String,
+    val port: Int,
+)

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketTransport.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketTransport.kt
@@ -1,0 +1,91 @@
+package com.softartdev.ktlan.data.socket
+
+import io.ktor.network.selector.ActorSelectorManager
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.bind
+import io.ktor.network.sockets.connect
+import io.ktor.network.sockets.tcp
+import io.ktor.network.sockets.tryClose
+import io.ktor.utils.io.CancellationException
+import io.ktor.utils.io.readUTF8Line
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Simple TCP transport utilities.
+ */
+object SocketTransport {
+
+    /** Represents an established chat connection. */
+    class ChatConnection(private val socket: Socket) {
+        private val input = socket.openReadChannel()
+        private val output = socket.openWriteChannel(autoFlush = true)
+
+        /** Stream of incoming text lines. */
+        val incoming: Flow<String> = flow {
+            while (!input.isClosedForRead) {
+                val line = try {
+                    input.readUTF8Line()
+                } catch (_: CancellationException) {
+                    null
+                }
+                line ?: break
+                emit(line)
+            }
+        }
+
+        /** Sends a single line. */
+        suspend fun send(line: String) {
+            output.writeStringUtf8(line)
+            output.writeStringUtf8("\n")
+        }
+
+        /** Closes the connection. */
+        suspend fun close() {
+            socket.close()
+        }
+    }
+
+    /** Starts a TCP server and waits for the first client connection. */
+    suspend fun startServer(bindHost: String, bindPort: Int): Pair<ChatConnection, suspend () -> Unit> {
+        val selector = ActorSelectorManager(Dispatchers.IO)
+        val serverSocket = aSocket(selector).tcp().bind(bindHost, bindPort)
+        val client = serverSocket.accept()
+        val connection = ChatConnection(client)
+        val stop: suspend () -> Unit = {
+            connection.close()
+            serverSocket.tryClose()
+            selector.close()
+        }
+        return connection to stop
+    }
+
+    /** Connects to a remote TCP server. */
+    suspend fun connect(remote: SocketEndpoint): ChatConnection {
+        val selector = ActorSelectorManager(Dispatchers.IO)
+        val socket = aSocket(selector).tcp().connect(remote.host, remote.port)
+        return ChatConnection(socket)
+    }
+
+    /** Parses either "host:port" or "ktlan://tcp?host=...&port=..." strings. */
+    fun parseEndpoint(text: String): SocketEndpoint? {
+        val trimmed = text.trim()
+        if (trimmed.startsWith("ktlan://tcp")) {
+            return runCatching {
+                val url = io.ktor.http.Url(trimmed)
+                val host = url.parameters["host"] ?: return null
+                val port = url.parameters["port"]?.toIntOrNull() ?: return null
+                SocketEndpoint(host, port)
+            }.getOrNull()
+        }
+        val parts = trimmed.split(":")
+        if (parts.size == 2) {
+            val port = parts[1].toIntOrNull() ?: return null
+            return SocketEndpoint(parts[0], port)
+        }
+        return null
+    }
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
@@ -1,8 +1,10 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.domain.repo.ConnectRepo
+import com.softartdev.ktlan.domain.repo.SocketRepo
 import com.softartdev.ktlan.domain.repo.ScanRepo
 import com.softartdev.ktlan.presentation.connect.ConnectViewModel
+import com.softartdev.ktlan.presentation.socket.SocketViewModel
 import com.softartdev.ktlan.presentation.scan.ScanViewModel
 import com.softartdev.ktlan.presentation.settings.SettingsViewModel
 import org.koin.core.module.Module
@@ -19,10 +21,12 @@ expect val dataModule: Module
 val domainModule: Module = module {
     factoryOf(::ScanRepo)
     singleOf(::ConnectRepo)
+    singleOf(::SocketRepo)
 }
 
 val presentationModule: Module = module {
     viewModelOf(::ScanViewModel)
     viewModelOf(::ConnectViewModel)
+    viewModelOf(::SocketViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/ChatMessage.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/ChatMessage.kt
@@ -1,0 +1,12 @@
+package com.softartdev.ktlan.domain.model
+
+/**
+ * Simple chat message with sender information.
+ */
+data class ChatMessage(
+    val sender: Sender,
+    val text: String,
+    val timestamp: Long,
+) {
+    enum class Sender { Local, Remote }
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
@@ -1,0 +1,79 @@
+package com.softartdev.ktlan.domain.repo
+
+import com.softartdev.ktlan.data.socket.SocketEndpoint
+import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.domain.model.ChatMessage
+import com.softartdev.ktlan.domain.model.ChatMessage.Sender
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+
+/**
+ * Repository managing a single TCP chat session.
+ */
+class SocketRepo(
+    private val dispatchers: CoroutineDispatchers,
+) {
+    private val scope = CoroutineScope(dispatchers.io)
+    private var connectionJob: Job? = null
+    private var connection: SocketTransport.ChatConnection? = null
+    private var stopServer: (suspend () -> Unit)? = null
+
+    private val mutableMessages = MutableSharedFlow<ChatMessage>()
+    val messages: Flow<ChatMessage> = mutableMessages.asSharedFlow()
+
+    /** Starts a server and waits for the first client. */
+    suspend fun startServer(bindHost: String, bindPort: Int) {
+        stop()
+        val (conn, stop) = SocketTransport.startServer(bindHost, bindPort)
+        connection = conn
+        stopServer = stop
+        observeIncoming(conn)
+    }
+
+    /** Connects to a remote host. */
+    suspend fun connectTo(remoteHost: String, remotePort: Int) {
+        stop()
+        val conn = SocketTransport.connect(SocketEndpoint(remoteHost, remotePort))
+        connection = conn
+        observeIncoming(conn)
+    }
+
+    /** Sends a text line to the peer. */
+    suspend fun send(text: String) {
+        val conn = connection ?: return
+        conn.send(text)
+        mutableMessages.emit(
+            ChatMessage(Sender.Local, text, Clock.System.now().toEpochMilliseconds())
+        )
+    }
+
+    /** Stops any running server and closes current connection. */
+    suspend fun stop() {
+        connectionJob?.cancel()
+        connectionJob = null
+        connection?.close()
+        connection = null
+        stopServer?.invoke()
+        stopServer = null
+    }
+
+    private fun observeIncoming(conn: SocketTransport.ChatConnection) {
+        connectionJob = scope.launch {
+            conn.incoming.collect { line ->
+                mutableMessages.emit(
+                    ChatMessage(
+                        Sender.Remote,
+                        line,
+                        Clock.System.now().toEpochMilliseconds()
+                    )
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketAction.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketAction.kt
@@ -1,0 +1,16 @@
+package com.softartdev.ktlan.presentation.socket
+
+/** Possible actions from the socket screen. */
+sealed interface SocketAction {
+    data class StartServer(val bindHost: String, val bindPort: String) : SocketAction
+    data object StopAll : SocketAction
+    data class Connect(val remoteHost: String, val remotePort: String) : SocketAction
+    data class Send(val text: String) : SocketAction
+    data object ShowQrForServer : SocketAction
+    data class ApplyQrPayload(val payload: String) : SocketAction
+    data class EditDraft(val newText: String) : SocketAction
+    data class SetBindHost(val value: String) : SocketAction
+    data class SetBindPort(val value: String) : SocketAction
+    data class SetRemoteHost(val value: String) : SocketAction
+    data class SetRemotePort(val value: String) : SocketAction
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketResult.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketResult.kt
@@ -1,0 +1,19 @@
+package com.softartdev.ktlan.presentation.socket
+
+import com.softartdev.ktlan.domain.model.ChatMessage
+
+/**
+ * UI state for the socket chat screen.
+ */
+data class SocketResult(
+    val loading: Boolean = false,
+    val serverRunning: Boolean = false,
+    val connected: Boolean = false,
+    val bindHost: String = "0.0.0.0",
+    val bindPort: String = "51337",
+    val remoteHost: String = "",
+    val remotePort: String = "51337",
+    val messages: List<ChatMessage> = emptyList(),
+    val draft: String = "",
+    val error: String? = null,
+)

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
@@ -1,0 +1,99 @@
+package com.softartdev.ktlan.presentation.socket
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.domain.model.ChatMessage
+import com.softartdev.ktlan.domain.repo.SocketRepo
+import com.softartdev.ktlan.presentation.navigation.AppNavGraph
+import com.softartdev.ktlan.presentation.navigation.Router
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the socket chat screen.
+ */
+class SocketViewModel(
+    private val router: Router,
+    private val socketRepo: SocketRepo,
+) : ViewModel() {
+
+    private val mutableState = MutableStateFlow(SocketResult())
+    val stateFlow: StateFlow<SocketResult> = mutableState
+    private var launched = false
+
+    fun launch() {
+        if (launched) return
+        launched = true
+        socketRepo.messages.onEach { message: ChatMessage ->
+            mutableState.update { it.copy(messages = it.messages + message) }
+        }.launchIn(viewModelScope)
+    }
+
+    fun onAction(action: SocketAction) = viewModelScope.launch {
+        when (action) {
+            is SocketAction.StartServer -> startServer(action.bindHost, action.bindPort)
+            is SocketAction.Connect -> connect(action.remoteHost, action.remotePort)
+            SocketAction.StopAll -> stopAll()
+            is SocketAction.Send -> send(action.text)
+            SocketAction.ShowQrForServer -> showQr()
+            is SocketAction.ApplyQrPayload -> applyQrPayload(action.payload)
+            is SocketAction.EditDraft -> mutableState.update { it.copy(draft = action.newText) }
+            is SocketAction.SetBindHost -> mutableState.update { it.copy(bindHost = action.value) }
+            is SocketAction.SetBindPort -> mutableState.update { it.copy(bindPort = action.value) }
+            is SocketAction.SetRemoteHost -> mutableState.update { it.copy(remoteHost = action.value) }
+            is SocketAction.SetRemotePort -> mutableState.update { it.copy(remotePort = action.value) }
+        }
+    }
+
+    private suspend fun startServer(host: String, port: String) {
+        mutableState.update { it.copy(loading = true, error = null) }
+        runCatching { socketRepo.startServer(host, port.toInt()) }
+            .onSuccess {
+                mutableState.update { it.copy(loading = false, serverRunning = true, connected = true) }
+            }
+            .onFailure { e ->
+                mutableState.update { it.copy(loading = false, error = e.message) }
+            }
+    }
+
+    private suspend fun connect(host: String, port: String) {
+        mutableState.update { it.copy(loading = true, error = null) }
+        runCatching { socketRepo.connectTo(host, port.toInt()) }
+            .onSuccess {
+                mutableState.update { it.copy(loading = false, connected = true, serverRunning = false) }
+            }
+            .onFailure { e ->
+                mutableState.update { it.copy(loading = false, error = e.message) }
+            }
+    }
+
+    private suspend fun send(text: String) {
+        socketRepo.send(text)
+        mutableState.update { it.copy(draft = "") }
+    }
+
+    private suspend fun stopAll() {
+        socketRepo.stop()
+        mutableState.update { it.copy(serverRunning = false, connected = false) }
+    }
+
+    private fun showQr() {
+        val state = mutableState.value
+        val url = "ktlan://tcp?host=${state.bindHost}&port=${state.bindPort}&v=1"
+        router.navigate(AppNavGraph.QrDialog(url))
+    }
+
+    private fun applyQrPayload(payload: String) {
+        val endpoint = SocketTransport.parseEndpoint(payload)
+        if (endpoint != null) {
+            mutableState.update { it.copy(remoteHost = endpoint.host, remotePort = endpoint.port.toString()) }
+        } else {
+            mutableState.update { it.copy(error = "Invalid QR data") }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ktor-network dependency
- implement simple TCP transport and repo
- introduce SocketViewModel and actions
- create LAN Chat screen and wire navigation
- update DI modules and strings

## Testing
- `./gradlew :shared:build :composeApp:compileKotlinDesktop` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68871364550c83309d05ddfcfc3dbfeb