### PR TITLE
Add basic socket chat

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -30,4 +30,15 @@
     <string name="scan_qr">Scan QR</string>
     <string name="cancelled">Cancelled</string>
     <string name="camera_is_not_available">Camera is not available</string>
+    <string name="lan_chat">LAN Chat</string>
+    <string name="bind_host">Bind host</string>
+    <string name="port">Port</string>
+    <string name="start_server">Start server</string>
+    <string name="stop">Stop</string>
+    <string name="show_qr">Show QR</string>
+    <string name="remote_host">Remote host</string>
+    <string name="connect">Connect</string>
+    <string name="type_message">Type a message…</string>
+    <string name="send">Send</string>
+    <string name="your_ip">Your IP</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
@@ -27,7 +27,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.softartdev.ktlan.connect.ConnectScreen
+import com.softartdev.ktlan.socket.SocketConnectScreen
 import com.softartdev.ktlan.isImeVisible
 import com.softartdev.ktlan.presentation.navigation.AppNavGraph
 import com.softartdev.ktlan.scan.ScanScreen
@@ -63,7 +63,7 @@ fun MainBottomNavScreen(
                 }
                 composable<AppNavGraph.BottomTab.Connect> {
                     selectedTab = AppNavGraph.BottomTab.Connect
-                    ConnectScreen(connectViewModel = koinViewModel())
+                    SocketConnectScreen(viewModel = koinViewModel())
                 }
                 composable<AppNavGraph.BottomTab.Settings> {
                     selectedTab = AppNavGraph.BottomTab.Settings

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
@@ -1,0 +1,145 @@
+package com.softartdev.ktlan.socket
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.softartdev.ktlan.presentation.socket.SocketAction
+import com.softartdev.ktlan.presentation.socket.SocketResult
+import com.softartdev.ktlan.presentation.socket.SocketViewModel
+import ktlan.composeapp.generated.resources.Res
+import ktlan.composeapp.generated.resources.bind_host
+import ktlan.composeapp.generated.resources.connect
+import ktlan.composeapp.generated.resources.lan_chat
+import ktlan.composeapp.generated.resources.port
+import ktlan.composeapp.generated.resources.remote_host
+import ktlan.composeapp.generated.resources.send
+import ktlan.composeapp.generated.resources.show_qr
+import ktlan.composeapp.generated.resources.start_server
+import ktlan.composeapp.generated.resources.stop
+import ktlan.composeapp.generated.resources.type_message
+import ktlan.composeapp.generated.resources.your_ip
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SocketConnectScreen(viewModel: SocketViewModel) {
+    val result by viewModel.stateFlow.collectAsState()
+    LaunchedEffect(viewModel) { viewModel.launch() }
+    SocketConnectContent(result, viewModel::onAction)
+}
+
+@Composable
+fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(text = stringResource(Res.string.lan_chat))
+        Text(text = stringResource(Res.string.your_ip) + ": " + result.bindHost)
+        Spacer(Modifier.height(8.dp))
+        Text(text = stringResource(Res.string.bind_host))
+        Row {
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = result.bindHost,
+                onValueChange = { onAction(SocketAction.SetBindHost(it)) }
+            )
+            Spacer(Modifier.width(8.dp))
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = result.bindPort,
+                onValueChange = { onAction(SocketAction.SetBindPort(it)) },
+                label = { Text(stringResource(Res.string.port)) }
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { onAction(SocketAction.StartServer(result.bindHost, result.bindPort)) }) {
+                Text(stringResource(Res.string.start_server))
+            }
+            Button(onClick = { onAction(SocketAction.StopAll) }) { Text(stringResource(Res.string.stop)) }
+            Button(onClick = { onAction(SocketAction.ShowQrForServer) }) { Text(stringResource(Res.string.show_qr)) }
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(text = stringResource(Res.string.remote_host))
+        Row {
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = result.remoteHost,
+                onValueChange = { onAction(SocketAction.SetRemoteHost(it)) }
+            )
+            Spacer(Modifier.width(8.dp))
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = result.remotePort,
+                onValueChange = { onAction(SocketAction.SetRemotePort(it)) },
+                label = { Text(stringResource(Res.string.port)) }
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { onAction(SocketAction.Connect(result.remoteHost, result.remotePort)) }) {
+                Text(stringResource(Res.string.connect))
+            }
+            Button(onClick = { onAction(SocketAction.ApplyQrPayload("")) }) {
+                Text(stringResource(Res.string.scan_qr))
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(result.messages) { message ->
+                ListItem(
+                    headlineContent = { Text(text = message.text) },
+                    overlineContent = { Text(if (message.sender == com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local) "You" else "Peer") }
+                )
+                HorizontalDivider()
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = result.draft,
+                onValueChange = { onAction(SocketAction.EditDraft(it)) },
+                label = { Text(stringResource(Res.string.type_message)) }
+            )
+            Button(onClick = { onAction(SocketAction.Send(result.draft)) }) {
+                Text(stringResource(Res.string.send))
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SocketConnectPreview() {
+    val messages = listOf(
+        com.softartdev.ktlan.domain.model.ChatMessage(
+            com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local,
+            "Hello",
+            0
+        ),
+        com.softartdev.ktlan.domain.model.ChatMessage(
+            com.softartdev.ktlan.domain.model.ChatMessage.Sender.Remote,
+            "Hi",
+            0
+        )
+    )
+    SocketConnectContent(
+        result = SocketResult(connected = true, messages = messages, bindHost = "192.168.1.2"),
+        onAction = {}
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
@@ -4,14 +4,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -20,23 +31,23 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.softartdev.ktlan.domain.model.ChatMessage
 import com.softartdev.ktlan.presentation.socket.SocketAction
 import com.softartdev.ktlan.presentation.socket.SocketResult
 import com.softartdev.ktlan.presentation.socket.SocketViewModel
 import ktlan.composeapp.generated.resources.Res
 import ktlan.composeapp.generated.resources.bind_host
 import ktlan.composeapp.generated.resources.connect
-import ktlan.composeapp.generated.resources.lan_chat
 import ktlan.composeapp.generated.resources.port
 import ktlan.composeapp.generated.resources.remote_host
 import ktlan.composeapp.generated.resources.scan_qr
-import ktlan.composeapp.generated.resources.send
 import ktlan.composeapp.generated.resources.show_qr
 import ktlan.composeapp.generated.resources.start_server
 import ktlan.composeapp.generated.resources.stop
 import ktlan.composeapp.generated.resources.type_message
-import ktlan.composeapp.generated.resources.your_ip
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -49,10 +60,32 @@ fun SocketConnectScreen(viewModel: SocketViewModel) {
 
 @Composable
 fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit) {
-    Column(modifier = Modifier.padding(16.dp)) {
-        Text(text = stringResource(Res.string.lan_chat))
-        Text(text = stringResource(Res.string.your_ip) + ": " + result.bindHost)
-        Spacer(Modifier.height(8.dp))
+    Column(modifier = Modifier) {
+        SocketConnectSettings(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            result = result,
+            onAction = onAction
+        )
+        SocketConnectMessages(
+            modifier = Modifier.weight(1f).padding(horizontal = 16.dp),
+            result = result,
+        )
+        SocketConnectInput(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            result = result,
+            onAction = onAction
+        )
+    }
+}
+
+@Composable
+fun SocketConnectSettings(
+    modifier: Modifier = Modifier,
+    result: SocketResult,
+    onAction: (SocketAction) -> Unit
+) {
+    if (result.loading) LinearProgressIndicator(Modifier.fillMaxWidth())
+    Column(modifier) {
         Text(text = stringResource(Res.string.bind_host))
         Row {
             TextField(
@@ -69,13 +102,15 @@ fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit)
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = { onAction(SocketAction.StartServer(result.bindHost, result.bindPort)) }) {
+            Button(onClick = {
+                onAction(SocketAction.StartServer(result.bindHost, result.bindPort))
+            }) {
                 Text(stringResource(Res.string.start_server))
             }
             Button(onClick = { onAction(SocketAction.StopAll) }) { Text(stringResource(Res.string.stop)) }
             Button(onClick = { onAction(SocketAction.ShowQrForServer) }) { Text(stringResource(Res.string.show_qr)) }
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(8.dp))
         Text(text = stringResource(Res.string.remote_host))
         Row {
             TextField(
@@ -92,7 +127,9 @@ fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit)
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = { onAction(SocketAction.Connect(result.remoteHost, result.remotePort)) }) {
+            Button(onClick = {
+                onAction(SocketAction.Connect(result.remoteHost, result.remotePort))
+            }) {
                 Text(stringResource(Res.string.connect))
             }
             Button(onClick = { onAction(SocketAction.ApplyQrPayload("")) }) {
@@ -100,25 +137,61 @@ fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit)
             }
         }
         Spacer(Modifier.height(16.dp))
-        LazyColumn(modifier = Modifier.weight(1f)) {
-            items(result.messages) { message ->
-                ListItem(
-                    headlineContent = { Text(text = message.text) },
-                    overlineContent = { Text(if (message.sender == com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local) "You" else "Peer") }
-                )
-                HorizontalDivider()
-            }
+    }
+}
+
+@Composable
+fun SocketConnectMessages(
+    modifier: Modifier = Modifier,
+    result: SocketResult
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(result.messages.size) {
+        if (result.messages.isNotEmpty()) {
+            listState.animateScrollToItem(result.messages.lastIndex)
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            TextField(
-                modifier = Modifier.weight(1f),
-                value = result.draft,
-                onValueChange = { onAction(SocketAction.EditDraft(it)) },
-                label = { Text(stringResource(Res.string.type_message)) }
+    }
+    LazyColumn(modifier, state = listState) {
+        items(result.messages) { message ->
+            ListItem(
+                headlineContent = { Text(text = message.text) },
+                overlineContent = { Text(if (message.sender == ChatMessage.Sender.Local) "You" else "Peer") }
             )
-            Button(onClick = { onAction(SocketAction.Send(result.draft)) }) {
-                Text(stringResource(Res.string.send))
-            }
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+fun SocketConnectInput(
+    modifier: Modifier = Modifier,
+    result: SocketResult,
+    onAction: (SocketAction) -> Unit
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(bottom = 8.dp),
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.weight(1f),
+            value = result.draft,
+            onValueChange = { onAction(SocketAction.EditDraft(it)) },
+            label = { Text(stringResource(Res.string.type_message)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Send
+            ),
+            keyboardActions = KeyboardActions(
+                onSend = { onAction(SocketAction.Send(result.draft)) }
+            )
+        )
+        FloatingActionButton(
+            modifier = Modifier.size(56.dp),
+            onClick = { onAction(SocketAction.Send(result.draft)) }
+        ) {
+            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null)
         }
     }
 }
@@ -127,15 +200,15 @@ fun SocketConnectContent(result: SocketResult, onAction: (SocketAction) -> Unit)
 @Composable
 fun SocketConnectPreview() {
     val messages = listOf(
-        com.softartdev.ktlan.domain.model.ChatMessage(
-            com.softartdev.ktlan.domain.model.ChatMessage.Sender.Local,
-            "Hello",
-            0
+        ChatMessage(
+            sender = ChatMessage.Sender.Local,
+            text = "Hello",
+            timestamp = 0
         ),
-        com.softartdev.ktlan.domain.model.ChatMessage(
-            com.softartdev.ktlan.domain.model.ChatMessage.Sender.Remote,
-            "Hi",
-            0
+        ChatMessage(
+            sender = ChatMessage.Sender.Remote,
+            text = "Hi",
+            timestamp = 0
         )
     )
     SocketConnectContent(

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/socket/SocketConnectScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -31,6 +30,7 @@ import ktlan.composeapp.generated.resources.connect
 import ktlan.composeapp.generated.resources.lan_chat
 import ktlan.composeapp.generated.resources.port
 import ktlan.composeapp.generated.resources.remote_host
+import ktlan.composeapp.generated.resources.scan_qr
 import ktlan.composeapp.generated.resources.send
 import ktlan.composeapp.generated.resources.show_qr
 import ktlan.composeapp.generated.resources.start_server

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging" }
+ktor-network = { module = "io.ktor:ktor-network" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }
 koin-core-viewmodel = { module = "io.insert-koin:koin-core-viewmodel" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.cio)
             implementation(libs.ktor.client.logging)
+            implementation(libs.ktor.network)
             implementation(libs.koin.core)
             implementation(libs.koin.core.viewmodel)
             implementation(libs.androidx.lifecycle.viewmodel)

--- a/shared/src/androidMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.android.kt
+++ b/shared/src/androidMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.android.kt
@@ -1,0 +1,18 @@
+package com.softartdev.ktlan.data.socket
+
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/** Android implementation retrieving the first non-loopback IPv4 address. */
+actual suspend fun getLocalIp(dispatchers: CoroutineDispatchers): String = withContext(dispatchers.io) {
+    return@withContext try {
+        NetworkInterface.getNetworkInterfaces().toList()
+            .flatMap { it.inetAddresses.toList() }
+            .firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
+            ?.hostAddress ?: "0.0.0.0"
+    } catch (_: Throwable) {
+        "0.0.0.0"
+    }
+}

--- a/shared/src/androidMain/kotlin/com/softartdev/ktlan/di/sharedModules.android.kt
+++ b/shared/src/androidMain/kotlin/com/softartdev/ktlan/di/sharedModules.android.kt
@@ -1,12 +1,15 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.data.webrtc.AndroidClientWebRTC
+import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val dataModule: Module = module {
     factoryOf(::AndroidClientWebRTC) bind ServerlessRTCClient::class
+    singleOf(::SocketTransport)
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.kt
@@ -1,0 +1,8 @@
+package com.softartdev.ktlan.data.socket
+
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+
+/**
+ * Detect device's local IPv4 address. Returns "0.0.0.0" if detection fails.
+ */
+expect suspend fun getLocalIp(dispatchers: CoroutineDispatchers): String

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketEndpoint.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketEndpoint.kt
@@ -1,0 +1,4 @@
+package com.softartdev.ktlan.data.socket
+
+/** Host and port pair. */
+data class SocketEndpoint(val host: String, val port: Int)

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketTransport.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/socket/SocketTransport.kt
@@ -5,9 +5,6 @@ import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.Socket
 import io.ktor.network.sockets.ServerSocket
 import io.ktor.network.sockets.aSocket
-import io.ktor.network.sockets.tcp
-import io.ktor.network.sockets.connect
-import io.ktor.network.sockets.bind
 import io.ktor.network.sockets.openReadChannel
 import io.ktor.network.sockets.openWriteChannel
 import io.ktor.utils.io.ByteReadChannel

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
@@ -1,8 +1,10 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.domain.repo.ConnectRepo
+import com.softartdev.ktlan.domain.repo.SocketRepo
 import com.softartdev.ktlan.domain.repo.ScanRepo
 import com.softartdev.ktlan.presentation.connect.ConnectViewModel
+import com.softartdev.ktlan.presentation.socket.SocketViewModel
 import com.softartdev.ktlan.presentation.scan.ScanViewModel
 import com.softartdev.ktlan.presentation.settings.SettingsViewModel
 import org.koin.core.module.Module
@@ -19,10 +21,12 @@ expect val dataModule: Module
 val domainModule: Module = module {
     factoryOf(::ScanRepo)
     singleOf(::ConnectRepo)
+    singleOf(::SocketRepo)
 }
 
 val presentationModule: Module = module {
     viewModelOf(::ScanViewModel)
     viewModelOf(::ConnectViewModel)
+    viewModelOf(::SocketViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/ChatMessage.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/ChatMessage.kt
@@ -1,0 +1,10 @@
+package com.softartdev.ktlan.domain.model
+
+/** Simple chat message with sender information. */
+data class ChatMessage(
+    val sender: Sender,
+    val text: String,
+    val timestamp: Long
+) {
+    enum class Sender { Local, Remote }
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
@@ -8,6 +8,7 @@ import com.softartdev.ktlan.data.socket.getLocalIp
 import com.softartdev.ktlan.domain.model.ChatMessage
 import com.softartdev.ktlan.domain.model.ChatMessage.Sender
 import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -34,6 +35,7 @@ open class SocketRepo(
 
     /** Start server and wait for the first incoming client. */
     open suspend fun startServer(bindHost: String, bindPort: Int) {
+        Napier.d("Starting server on $bindHost:$bindPort")
         stop()
         val (conn, stop) = transport.startServer(bindHost, bindPort)
         connection = conn
@@ -43,6 +45,7 @@ open class SocketRepo(
 
     /** Connect to remote endpoint. */
     open suspend fun connectTo(remoteHost: String, remotePort: Int) {
+        Napier.d("Connecting to $remoteHost:$remotePort")
         stop()
         val conn = transport.connect(SocketEndpoint(remoteHost, remotePort))
         connection = conn

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.softartdev.ktlan.domain.repo
 
 import com.softartdev.ktlan.data.socket.SocketEndpoint
@@ -11,6 +13,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /**
  * Repository managing one active TCP chat session.
@@ -71,5 +75,5 @@ open class SocketRepo(
         }
     }
 
-    private fun now(): Long = kotlin.system.getTimeMillis()
+    private fun now(): Long = Clock.System.now().toEpochMilliseconds()
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/SocketRepo.kt
@@ -1,0 +1,75 @@
+package com.softartdev.ktlan.domain.repo
+
+import com.softartdev.ktlan.data.socket.SocketEndpoint
+import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.data.socket.getLocalIp
+import com.softartdev.ktlan.domain.model.ChatMessage
+import com.softartdev.ktlan.domain.model.ChatMessage.Sender
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Repository managing one active TCP chat session.
+ */
+open class SocketRepo(
+    private val transport: SocketTransport,
+    private val dispatchers: CoroutineDispatchers
+) {
+    private val scope = CoroutineScope(dispatchers.default)
+    private val messages = MutableSharedFlow<ChatMessage>()
+
+    private var stopHandle: (suspend () -> Unit)? = null
+    private var connection: SocketTransport.ChatConnection? = null
+
+    /** Stream of incoming chat messages. */
+    open fun observeMessages(): Flow<ChatMessage> = messages.asSharedFlow()
+
+    /** Start server and wait for the first incoming client. */
+    open suspend fun startServer(bindHost: String, bindPort: Int) {
+        stop()
+        val (conn, stop) = transport.startServer(bindHost, bindPort)
+        connection = conn
+        stopHandle = stop
+        collectIncoming(conn)
+    }
+
+    /** Connect to remote endpoint. */
+    open suspend fun connectTo(remoteHost: String, remotePort: Int) {
+        stop()
+        val conn = transport.connect(SocketEndpoint(remoteHost, remotePort))
+        connection = conn
+        stopHandle = null
+        collectIncoming(conn)
+    }
+
+    /** Send a text line to peer. */
+    open suspend fun send(text: String) {
+        connection?.send(text)
+        messages.emit(ChatMessage(Sender.Local, text, now()))
+    }
+
+    /** Stop any running server or connection. */
+    open suspend fun stop() {
+        stopHandle?.invoke()
+        stopHandle = null
+        connection?.close()
+        connection = null
+    }
+
+    /** Best effort local IP detection. */
+    open suspend fun getLocalIp(): String = getLocalIp(dispatchers)
+
+    private fun collectIncoming(conn: SocketTransport.ChatConnection) {
+        scope.launch {
+            conn.incoming.collect { line ->
+                messages.emit(ChatMessage(Sender.Remote, line, now()))
+            }
+        }
+    }
+
+    private fun now(): Long = kotlin.system.getTimeMillis()
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketResult.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketResult.kt
@@ -1,0 +1,31 @@
+package com.softartdev.ktlan.presentation.socket
+
+import com.softartdev.ktlan.domain.model.ChatMessage
+
+/** ViewModel state for socket chat screen. */
+data class SocketResult(
+    val loading: Boolean = false,
+    val serverRunning: Boolean = false,
+    val connected: Boolean = false,
+    val bindHost: String = "0.0.0.0",
+    val bindPort: String = "51337",
+    val remoteHost: String = "",
+    val remotePort: String = "51337",
+    val messages: List<ChatMessage> = emptyList(),
+    val draft: String = "",
+    val error: String? = null
+)
+
+sealed interface SocketAction {
+    data class StartServer(val bindHost: String, val bindPort: String) : SocketAction
+    data object StopAll : SocketAction
+    data class Connect(val remoteHost: String, val remotePort: String) : SocketAction
+    data class Send(val text: String) : SocketAction
+    data object ShowQrForServer : SocketAction
+    data class ApplyQrPayload(val payload: String) : SocketAction
+    data class EditDraft(val newText: String) : SocketAction
+    data class SetBindHost(val bindHost: String) : SocketAction
+    data class SetBindPort(val bindPort: String) : SocketAction
+    data class SetRemoteHost(val remoteHost: String) : SocketAction
+    data class SetRemotePort(val remotePort: String) : SocketAction
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
@@ -6,6 +6,7 @@ import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.domain.repo.SocketRepo
 import com.softartdev.ktlan.presentation.navigation.AppNavGraph
 import com.softartdev.ktlan.presentation.navigation.Router
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -52,6 +53,7 @@ class SocketViewModel(
     }
 
     private fun startServer(host: String, portString: String) = viewModelScope.launch {
+        Napier.d("Starting server on $host:$portString")
         val port = portString.toIntOrNull()
         if (port == null) {
             state.update { it.copy(error = "Invalid port") }
@@ -60,25 +62,31 @@ class SocketViewModel(
         state.update { it.copy(loading = true, error = null) }
         runCatching { repo.startServer(host, port) }
             .onSuccess {
+                Napier.d("Server started successfully on $host:$portString")
                 state.update { it.copy(loading = false, serverRunning = true, connected = true) }
             }
             .onFailure { e ->
+                Napier.e("Failed to start server", e)
                 state.update { it.copy(loading = false, error = e.message) }
             }
     }
 
     private fun connect(host: String, portString: String) = viewModelScope.launch {
+        Napier.d("Connecting to $host:$portString")
         val port = portString.toIntOrNull()
         if (port == null) {
             state.update { it.copy(error = "Invalid port") }
+            Napier.e("Invalid port: $portString")
             return@launch
         }
         state.update { it.copy(loading = true, error = null) }
         runCatching { repo.connectTo(host, port) }
             .onSuccess {
+                Napier.d("Connected to $host:$portString")
                 state.update { it.copy(loading = false, connected = true) }
             }
             .onFailure { e ->
+                Napier.e("Failed to connect to $host:$portString", e)
                 state.update { it.copy(loading = false, error = e.message) }
             }
     }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
@@ -1,0 +1,112 @@
+package com.softartdev.ktlan.presentation.socket
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.domain.repo.SocketRepo
+import com.softartdev.ktlan.presentation.navigation.AppNavGraph
+import com.softartdev.ktlan.presentation.navigation.Router
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** ViewModel orchestrating socket chat operations. */
+class SocketViewModel(
+    private val router: Router,
+    private val repo: SocketRepo,
+    private val transport: SocketTransport
+) : ViewModel() {
+    private val state = MutableStateFlow(SocketResult())
+    val stateFlow: StateFlow<SocketResult> = state
+    private var launched = false
+
+    /** Subscribe to repo and prefill local IP. */
+    fun launch() {
+        if (launched) return
+        launched = true
+        viewModelScope.launch {
+            val ip = repo.getLocalIp()
+            state.update { it.copy(bindHost = ip) }
+        }
+        repo.observeMessages().onEach { msg ->
+            state.update { it.copy(messages = it.messages + msg) }
+        }.launchIn(viewModelScope)
+    }
+
+    /** Handle user actions. */
+    fun onAction(action: SocketAction) = viewModelScope.launch {
+        when (action) {
+            is SocketAction.StartServer -> startServer(action.bindHost, action.bindPort)
+            is SocketAction.Connect -> connect(action.remoteHost, action.remotePort)
+            SocketAction.StopAll -> stopAll()
+            is SocketAction.Send -> send(action.text)
+            SocketAction.ShowQrForServer -> showQr()
+            is SocketAction.ApplyQrPayload -> applyQr(action.payload)
+            is SocketAction.EditDraft -> state.update { it.copy(draft = action.newText) }
+            is SocketAction.SetBindHost -> state.update { it.copy(bindHost = action.bindHost) }
+            is SocketAction.SetBindPort -> state.update { it.copy(bindPort = action.bindPort) }
+            is SocketAction.SetRemoteHost -> state.update { it.copy(remoteHost = action.remoteHost) }
+            is SocketAction.SetRemotePort -> state.update { it.copy(remotePort = action.remotePort) }
+        }
+    }
+
+    private suspend fun startServer(host: String, portString: String) {
+        val port = portString.toIntOrNull()
+        if (port == null) {
+            state.update { it.copy(error = "Invalid port") }
+            return
+        }
+        state.update { it.copy(loading = true, error = null) }
+        runCatching { repo.startServer(host, port) }
+            .onSuccess {
+                state.update { it.copy(loading = false, serverRunning = true, connected = true) }
+            }
+            .onFailure { e ->
+                state.update { it.copy(loading = false, error = e.message) }
+            }
+    }
+
+    private suspend fun connect(host: String, portString: String) {
+        val port = portString.toIntOrNull()
+        if (port == null) {
+            state.update { it.copy(error = "Invalid port") }
+            return
+        }
+        state.update { it.copy(loading = true, error = null) }
+        runCatching { repo.connectTo(host, port) }
+            .onSuccess {
+                state.update { it.copy(loading = false, connected = true) }
+            }
+            .onFailure { e ->
+                state.update { it.copy(loading = false, error = e.message) }
+            }
+    }
+
+    private suspend fun send(text: String) {
+        repo.send(text)
+        state.update { it.copy(draft = "") }
+    }
+
+    private suspend fun stopAll() {
+        repo.stop()
+        state.update { it.copy(serverRunning = false, connected = false) }
+    }
+
+    private fun showQr() {
+        val current = state.value
+        val url = "ktlan://tcp?host=${current.bindHost}&port=${current.bindPort}&v=1"
+        router.navigate(AppNavGraph.QrDialog(url))
+    }
+
+    private fun applyQr(payload: String) {
+        val endpoint = transport.parse(payload)
+        if (endpoint != null) {
+            state.update { it.copy(remoteHost = endpoint.host, remotePort = endpoint.port.toString()) }
+        } else {
+            state.update { it.copy(error = "Invalid QR data") }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
@@ -37,27 +37,25 @@ class SocketViewModel(
     }
 
     /** Handle user actions. */
-    fun onAction(action: SocketAction) = viewModelScope.launch {
-        when (action) {
-            is SocketAction.StartServer -> startServer(action.bindHost, action.bindPort)
-            is SocketAction.Connect -> connect(action.remoteHost, action.remotePort)
-            SocketAction.StopAll -> stopAll()
-            is SocketAction.Send -> send(action.text)
-            SocketAction.ShowQrForServer -> showQr()
-            is SocketAction.ApplyQrPayload -> applyQr(action.payload)
-            is SocketAction.EditDraft -> state.update { it.copy(draft = action.newText) }
-            is SocketAction.SetBindHost -> state.update { it.copy(bindHost = action.bindHost) }
-            is SocketAction.SetBindPort -> state.update { it.copy(bindPort = action.bindPort) }
-            is SocketAction.SetRemoteHost -> state.update { it.copy(remoteHost = action.remoteHost) }
-            is SocketAction.SetRemotePort -> state.update { it.copy(remotePort = action.remotePort) }
-        }
+    fun onAction(action: SocketAction) = when (action) {
+        is SocketAction.StartServer -> startServer(action.bindHost, action.bindPort)
+        is SocketAction.Connect -> connect(action.remoteHost, action.remotePort)
+        is SocketAction.StopAll -> stopAll()
+        is SocketAction.Send -> send(action.text)
+        is SocketAction.ShowQrForServer -> showQr()
+        is SocketAction.ApplyQrPayload -> applyQr(action.payload)
+        is SocketAction.EditDraft -> state.update { it.copy(draft = action.newText) }
+        is SocketAction.SetBindHost -> state.update { it.copy(bindHost = action.bindHost) }
+        is SocketAction.SetBindPort -> state.update { it.copy(bindPort = action.bindPort) }
+        is SocketAction.SetRemoteHost -> state.update { it.copy(remoteHost = action.remoteHost) }
+        is SocketAction.SetRemotePort -> state.update { it.copy(remotePort = action.remotePort) }
     }
 
-    private suspend fun startServer(host: String, portString: String) {
+    private fun startServer(host: String, portString: String) = viewModelScope.launch {
         val port = portString.toIntOrNull()
         if (port == null) {
             state.update { it.copy(error = "Invalid port") }
-            return
+            return@launch
         }
         state.update { it.copy(loading = true, error = null) }
         runCatching { repo.startServer(host, port) }
@@ -69,11 +67,11 @@ class SocketViewModel(
             }
     }
 
-    private suspend fun connect(host: String, portString: String) {
+    private fun connect(host: String, portString: String) = viewModelScope.launch {
         val port = portString.toIntOrNull()
         if (port == null) {
             state.update { it.copy(error = "Invalid port") }
-            return
+            return@launch
         }
         state.update { it.copy(loading = true, error = null) }
         runCatching { repo.connectTo(host, port) }
@@ -85,12 +83,12 @@ class SocketViewModel(
             }
     }
 
-    private suspend fun send(text: String) {
+    private fun send(text: String) = viewModelScope.launch {
         repo.send(text)
         state.update { it.copy(draft = "") }
     }
 
-    private suspend fun stopAll() {
+    private fun stopAll() = viewModelScope.launch {
         repo.stop()
         state.update { it.copy(serverRunning = false, connected = false) }
     }

--- a/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
@@ -1,0 +1,89 @@
+package com.softartdev.ktlan.presentation.socket
+
+import com.softartdev.ktlan.domain.model.ChatMessage
+import com.softartdev.ktlan.domain.repo.SocketRepo
+import com.softartdev.ktlan.presentation.navigation.Router
+import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private class TestDispatchers(val dispatcher: CoroutineDispatcher = StandardTestDispatcher()) : CoroutineDispatchers {
+    override val default = dispatcher
+    override val main = dispatcher
+    override val unconfined = dispatcher
+    override val io = dispatcher
+}
+
+private class FakeRepo(private val dispatchers: CoroutineDispatchers) : SocketRepo(SocketTransport(dispatchers), dispatchers) {
+    val sent = mutableListOf<String>()
+    private val _messages = MutableSharedFlow<ChatMessage>()
+    override fun observeMessages() = _messages
+    override suspend fun getLocalIp(): String = "192.168.0.1"
+    override suspend fun startServer(bindHost: String, bindPort: Int) {}
+    override suspend fun connectTo(remoteHost: String, remotePort: Int) {}
+    override suspend fun send(text: String) { sent += text }
+    override suspend fun stop() {}
+    suspend fun emitIncoming(text: String) { _messages.emit(ChatMessage(ChatMessage.Sender.Remote, text, 0)) }
+}
+
+private class FakeRouter : Router {
+    var last: Any? = null
+    override fun setController(navController: Any) {}
+    override fun releaseController() {}
+    override fun <T : Any> navigate(route: T) { last = route }
+    override fun <T : Any> navigateClearingBackStack(route: T) { last = route }
+    override fun <T : Any> popBackStack(route: T, inclusive: Boolean, saveState: Boolean) = false
+    override fun popBackStack() = false
+}
+
+class SocketViewModelTest {
+    @Test
+    fun testInitialStatePrefilled() = runTest {
+        val dispatchers = TestDispatchers(testScheduler)
+        val repo = FakeRepo(dispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        vm.launch()
+        advanceUntilIdle()
+        assertEquals("192.168.0.1", vm.stateFlow.value.bindHost)
+    }
+
+    @Test
+    fun testSendAppendsMessage() = runTest {
+        val dispatchers = TestDispatchers(testScheduler)
+        val repo = FakeRepo(dispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        vm.launch()
+        vm.onAction(SocketAction.Send("hi"))
+        advanceUntilIdle()
+        assertEquals(listOf("hi"), repo.sent)
+    }
+
+    @Test
+    fun testApplyQrPayloadValid() = runTest {
+        val dispatchers = TestDispatchers(testScheduler)
+        val repo = FakeRepo(dispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        vm.launch()
+        vm.onAction(SocketAction.ApplyQrPayload("ktlan://tcp?host=1.2.3.4&port=5"))
+        advanceUntilIdle()
+        assertEquals("1.2.3.4", vm.stateFlow.value.remoteHost)
+        assertEquals("5", vm.stateFlow.value.remotePort)
+    }
+
+    @Test
+    fun testApplyQrPayloadInvalid() = runTest {
+        val dispatchers = TestDispatchers(testScheduler)
+        val repo = FakeRepo(dispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        vm.launch()
+        vm.onAction(SocketAction.ApplyQrPayload("wrong"))
+        advanceUntilIdle()
+        assertEquals("Invalid QR data", vm.stateFlow.value.error)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
@@ -11,12 +11,18 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private class TestDispatchers(dispatcher: CoroutineDispatcher = StandardTestDispatcher()) : CoroutineDispatchers {
+private class TestCoroutineDispatchers(
+    dispatcher: CoroutineDispatcher = StandardTestDispatcher()
+) : CoroutineDispatchers {
+    constructor(scheduler: TestCoroutineScheduler) : this(
+        dispatcher = StandardTestDispatcher(scheduler)
+    )
     override val default = dispatcher
     override val main = dispatcher
     override val unconfined = dispatcher
@@ -47,9 +53,9 @@ private class FakeRouter : Router {
 class SocketViewModelTest {
     @Test
     fun testInitialStatePrefilled() = runTest {
-        val dispatchers = TestDispatchers()
-        val repo = FakeRepo(dispatchers)
-        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        val testDispatchers = TestCoroutineDispatchers(scheduler = testScheduler)
+        val repo = FakeRepo(testDispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(testDispatchers))
         vm.launch()
         advanceUntilIdle()
         assertEquals("192.168.0.1", vm.stateFlow.value.bindHost)
@@ -57,9 +63,9 @@ class SocketViewModelTest {
 
     @Test
     fun testSendAppendsMessage() = runTest {
-        val dispatchers = TestDispatchers()
-        val repo = FakeRepo(dispatchers)
-        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        val testDispatchers = TestCoroutineDispatchers(scheduler = testScheduler)
+        val repo = FakeRepo(testDispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(testDispatchers))
         vm.launch()
         vm.onAction(SocketAction.Send("hi"))
         advanceUntilIdle()
@@ -68,9 +74,9 @@ class SocketViewModelTest {
 
     @Test
     fun testApplyQrPayloadValid() = runTest {
-        val dispatchers = TestDispatchers()
-        val repo = FakeRepo(dispatchers)
-        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        val testDispatchers = TestCoroutineDispatchers(scheduler = testScheduler)
+        val repo = FakeRepo(testDispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(testDispatchers))
         vm.launch()
         vm.onAction(SocketAction.ApplyQrPayload("ktlan://tcp?host=1.2.3.4&port=5"))
         advanceUntilIdle()
@@ -80,9 +86,9 @@ class SocketViewModelTest {
 
     @Test
     fun testApplyQrPayloadInvalid() = runTest {
-        val dispatchers = TestDispatchers()
-        val repo = FakeRepo(dispatchers)
-        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
+        val testDispatchers = TestCoroutineDispatchers(scheduler = testScheduler)
+        val repo = FakeRepo(testDispatchers)
+        val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(testDispatchers))
         vm.launch()
         vm.onAction(SocketAction.ApplyQrPayload("wrong"))
         advanceUntilIdle()

--- a/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.softartdev.ktlan.presentation.socket
 
 import com.softartdev.ktlan.domain.model.ChatMessage
@@ -6,6 +8,7 @@ import com.softartdev.ktlan.presentation.navigation.Router
 import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.domain.util.CoroutineDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -13,14 +16,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-private class TestDispatchers(val dispatcher: CoroutineDispatcher = StandardTestDispatcher()) : CoroutineDispatchers {
+private class TestDispatchers(dispatcher: CoroutineDispatcher = StandardTestDispatcher()) : CoroutineDispatchers {
     override val default = dispatcher
     override val main = dispatcher
     override val unconfined = dispatcher
     override val io = dispatcher
 }
 
-private class FakeRepo(private val dispatchers: CoroutineDispatchers) : SocketRepo(SocketTransport(dispatchers), dispatchers) {
+private class FakeRepo(dispatchers: CoroutineDispatchers) : SocketRepo(SocketTransport(dispatchers), dispatchers) {
     val sent = mutableListOf<String>()
     private val _messages = MutableSharedFlow<ChatMessage>()
     override fun observeMessages() = _messages
@@ -29,7 +32,6 @@ private class FakeRepo(private val dispatchers: CoroutineDispatchers) : SocketRe
     override suspend fun connectTo(remoteHost: String, remotePort: Int) {}
     override suspend fun send(text: String) { sent += text }
     override suspend fun stop() {}
-    suspend fun emitIncoming(text: String) { _messages.emit(ChatMessage(ChatMessage.Sender.Remote, text, 0)) }
 }
 
 private class FakeRouter : Router {
@@ -45,7 +47,7 @@ private class FakeRouter : Router {
 class SocketViewModelTest {
     @Test
     fun testInitialStatePrefilled() = runTest {
-        val dispatchers = TestDispatchers(testScheduler)
+        val dispatchers = TestDispatchers()
         val repo = FakeRepo(dispatchers)
         val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
         vm.launch()
@@ -55,7 +57,7 @@ class SocketViewModelTest {
 
     @Test
     fun testSendAppendsMessage() = runTest {
-        val dispatchers = TestDispatchers(testScheduler)
+        val dispatchers = TestDispatchers()
         val repo = FakeRepo(dispatchers)
         val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
         vm.launch()
@@ -66,7 +68,7 @@ class SocketViewModelTest {
 
     @Test
     fun testApplyQrPayloadValid() = runTest {
-        val dispatchers = TestDispatchers(testScheduler)
+        val dispatchers = TestDispatchers()
         val repo = FakeRepo(dispatchers)
         val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
         vm.launch()
@@ -78,7 +80,7 @@ class SocketViewModelTest {
 
     @Test
     fun testApplyQrPayloadInvalid() = runTest {
-        val dispatchers = TestDispatchers(testScheduler)
+        val dispatchers = TestDispatchers()
         val repo = FakeRepo(dispatchers)
         val vm = SocketViewModel(FakeRouter(), repo, SocketTransport(dispatchers))
         vm.launch()

--- a/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.ios.kt
+++ b/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.ios.kt
@@ -1,0 +1,6 @@
+package com.softartdev.ktlan.data.socket
+
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+
+/** iOS fallback returning placeholder. */
+actual suspend fun getLocalIp(dispatchers: CoroutineDispatchers): String = "0.0.0.0"

--- a/shared/src/iosMain/kotlin/com/softartdev/ktlan/di/sharedModules.ios.kt
+++ b/shared/src/iosMain/kotlin/com/softartdev/ktlan/di/sharedModules.ios.kt
@@ -1,12 +1,15 @@
 package com.softartdev.ktlan.di
 
+import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.data.webrtc.IOSClientWebRTC
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val dataModule: Module = module {
     factoryOf(::IOSClientWebRTC) bind ServerlessRTCClient::class
+    singleOf(::SocketTransport)
 }

--- a/shared/src/jvmMain/java/com/softartdev/ktlan/di/sharedModules.jvm.kt
+++ b/shared/src/jvmMain/java/com/softartdev/ktlan/di/sharedModules.jvm.kt
@@ -1,11 +1,14 @@
 package com.softartdev.ktlan.di
 
+import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.data.webrtc.JvmClientWebRTC
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val dataModule: org.koin.core.module.Module = module {
     factoryOf(::JvmClientWebRTC) bind ServerlessRTCClient::class
+    singleOf(::SocketTransport)
 }

--- a/shared/src/jvmMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.jvm.kt
@@ -1,0 +1,18 @@
+package com.softartdev.ktlan.data.socket
+
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/** JVM implementation retrieving the first non-loopback IPv4 address. */
+actual suspend fun getLocalIp(dispatchers: CoroutineDispatchers): String = withContext(dispatchers.io) {
+    return@withContext try {
+        NetworkInterface.getNetworkInterfaces().toList()
+            .flatMap { it.inetAddresses.toList() }
+            .firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
+            ?.hostAddress ?: "0.0.0.0"
+    } catch (_: Throwable) {
+        "0.0.0.0"
+    }
+}

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/socket/LocalIp.wasmJs.kt
@@ -1,0 +1,6 @@
+package com.softartdev.ktlan.data.socket
+
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+
+/** wasm fallback returning placeholder. */
+actual suspend fun getLocalIp(dispatchers: CoroutineDispatchers): String = "0.0.0.0"

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/di/sharedModules.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/di/sharedModules.wasmJs.kt
@@ -1,12 +1,15 @@
 package com.softartdev.ktlan.di
 
+import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import com.softartdev.ktlan.data.webrtc.WasmJsClientWebRTC
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val dataModule: Module = module {
     factoryOf(::WasmJsClientWebRTC) bind ServerlessRTCClient::class
+    singleOf(::SocketTransport)
 }


### PR DESCRIPTION
## Summary
- implement ktor tcp SocketTransport
- add SocketRepo and related viewmodel/state
- add Local IP utilities per platform
- create SocketConnectScreen UI and navigation
- wire DI for new repo and viewmodel
- extend string resources
- add simple tests for SocketViewModel

## Testing
- `./gradlew :shared:jvmTest --tests "com.softartdev.ktlan.presentation.socket.SocketViewModelTest"` *(fails: unresolved references)*

------
https://chatgpt.com/codex/tasks/task_e_6887246bc8948330a1aff27492f05215