### PR TITLE
Add Networks tab listing interfaces

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,4 +41,18 @@
     <string name="type_message">Type a message…</string>
     <string name="send">Send</string>
     <string name="your_ip">Your IP</string>
+    <string name="networks_title">Networks</string>
+    <string name="networks_refresh">Refresh</string>
+    <string name="networks_no_items">No interfaces found</string>
+    <string name="networks_interface">Interface</string>
+    <string name="networks_flags">Flags</string>
+    <string name="networks_flag_up">Up</string>
+    <string name="networks_flag_loopback">Loopback</string>
+    <string name="networks_flag_multicast">Multicast</string>
+    <string name="networks_ipv4">IPv4</string>
+    <string name="networks_ipv6">IPv6</string>
+    <string name="networks_copy">Copy</string>
+    <string name="networks_use">Use</string>
+    <string name="networks_your_ip">Your IP</string>
+    <string name="networks_show_all">Show all</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/main/MainBottomNavScreen.kt
@@ -30,13 +30,13 @@ import androidx.navigation.compose.rememberNavController
 import com.softartdev.ktlan.socket.SocketConnectScreen
 import com.softartdev.ktlan.isImeVisible
 import com.softartdev.ktlan.presentation.navigation.AppNavGraph
-import com.softartdev.ktlan.scan.ScanScreen
+import com.softartdev.ktlan.networks.NetworksScreen
 import com.softartdev.ktlan.settings.SettingsScreen
 import ktlan.composeapp.generated.resources.Res
 import ktlan.composeapp.generated.resources.app_name
 import ktlan.composeapp.generated.resources.connection
-import ktlan.composeapp.generated.resources.scan
 import ktlan.composeapp.generated.resources.settings
+import ktlan.composeapp.generated.resources.networks_title
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -57,9 +57,9 @@ fun MainBottomNavScreen(
                 navController = navController,
                 startDestination = startBottomTab,
             ) {
-                composable<AppNavGraph.BottomTab.Scan> {
-                    selectedTab = AppNavGraph.BottomTab.Scan
-                    ScanScreen(scanViewModel = koinViewModel())
+                composable<AppNavGraph.BottomTab.Networks> {
+                    selectedTab = AppNavGraph.BottomTab.Networks
+                    NetworksScreen(viewModel = koinViewModel())
                 }
                 composable<AppNavGraph.BottomTab.Connect> {
                     selectedTab = AppNavGraph.BottomTab.Connect
@@ -74,7 +74,7 @@ fun MainBottomNavScreen(
         bottomBar = {
             if (!WindowInsets.isImeVisible) NavigationBar {
                 sequenceOf(
-                    AppNavGraph.BottomTab.Scan,
+                    AppNavGraph.BottomTab.Networks,
                     AppNavGraph.BottomTab.Connect,
                     AppNavGraph.BottomTab.Settings
                 ).forEach { bottomTab: AppNavGraph.BottomTab ->
@@ -97,7 +97,7 @@ fun MainBottomNavScreen(
                                 text = stringResource(
                                     resource = when (bottomTab) {
                                         AppNavGraph.BottomTab.Connect -> Res.string.connection
-                                        AppNavGraph.BottomTab.Scan -> Res.string.scan
+                                        AppNavGraph.BottomTab.Networks -> Res.string.networks_title
                                         AppNavGraph.BottomTab.Settings -> Res.string.settings
                                     }
                                 )
@@ -106,7 +106,7 @@ fun MainBottomNavScreen(
                         icon = {
                             Icon(
                                 imageVector = when (bottomTab) {
-                                    AppNavGraph.BottomTab.Scan -> Icons.Default.Plagiarism
+                                    AppNavGraph.BottomTab.Networks -> Icons.Default.Plagiarism
                                     AppNavGraph.BottomTab.Connect -> Icons.Outlined.ConnectWithoutContact
                                     AppNavGraph.BottomTab.Settings -> Icons.Default.Settings
                                 },

--- a/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/networks/NetworksScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/softartdev/ktlan/networks/NetworksScreen.kt
@@ -1,0 +1,153 @@
+package com.softartdev.ktlan.networks
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.presentation.networks.NetworksAction
+import com.softartdev.ktlan.presentation.networks.NetworksResult
+import com.softartdev.ktlan.presentation.networks.NetworksViewModel
+import ktlan.composeapp.generated.resources.Res
+import ktlan.composeapp.generated.resources.networks_copy
+import ktlan.composeapp.generated.resources.networks_flag_loopback
+import ktlan.composeapp.generated.resources.networks_flag_multicast
+import ktlan.composeapp.generated.resources.networks_flag_up
+import ktlan.composeapp.generated.resources.networks_flags
+import ktlan.composeapp.generated.resources.networks_interface
+import ktlan.composeapp.generated.resources.networks_ipv4
+import ktlan.composeapp.generated.resources.networks_ipv6
+import ktlan.composeapp.generated.resources.networks_no_items
+import ktlan.composeapp.generated.resources.networks_refresh
+import ktlan.composeapp.generated.resources.networks_title
+import ktlan.composeapp.generated.resources.networks_use
+import ktlan.composeapp.generated.resources.networks_your_ip
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun NetworksScreen(viewModel: NetworksViewModel) {
+    val result by viewModel.stateFlow.collectAsState()
+    LaunchedEffect(viewModel) { viewModel.launch() }
+    NetworksContent(result, viewModel::onAction, viewModel)
+}
+
+@Composable
+fun NetworksContent(result: NetworksResult, onAction: (NetworksAction) -> Unit, viewModel: NetworksViewModel? = null) {
+    val clipboard: ClipboardManager = LocalClipboardManager.current
+    val yourIp = viewModel?.let { remember { mutableStateOf<String?>(null) } }
+    LaunchedEffect(Unit) {
+        if (viewModel != null) yourIp?.value = viewModel.guessLocalIp()
+    }
+    Column(modifier = Modifier.padding(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(stringResource(Res.string.networks_title))
+            Button(onClick = { onAction(NetworksAction.Refresh) }) {
+                Icon(Icons.Default.Refresh, contentDescription = null)
+                Spacer(Modifier.padding(horizontal = 4.dp))
+                Text(stringResource(Res.string.networks_refresh))
+            }
+        }
+        yourIp?.value?.let { ip ->
+            Text(text = stringResource(Res.string.networks_your_ip) + ": $ip")
+        }
+        Spacer(Modifier.padding(vertical = 4.dp))
+        if (result.interfaces.isEmpty()) {
+            Text(stringResource(Res.string.networks_no_items))
+        } else {
+            LazyColumn {
+                items(result.interfaces) { ni: NetworkInterfaceInfo ->
+                    NetworkInterfaceItem(ni, onAction, clipboard)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NetworkInterfaceItem(info: NetworkInterfaceInfo, onAction: (NetworksAction) -> Unit, clipboard: ClipboardManager) {
+    Card(modifier = Modifier.padding(vertical = 4.dp)) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            Text(stringResource(Res.string.networks_interface) + ": ${info.name}")
+            Text(stringResource(Res.string.networks_flags) + ": " + buildString {
+                if (info.isUp) append(stringResource(Res.string.networks_flag_up) + " ")
+                if (info.isLoopback) append(stringResource(Res.string.networks_flag_loopback) + " ")
+                if (info.supportsMulticast) append(stringResource(Res.string.networks_flag_multicast))
+            })
+            if (info.ipv4.isNotEmpty()) {
+                Text(stringResource(Res.string.networks_ipv4))
+                info.ipv4.forEach { ip ->
+                    ListItem(
+                        headlineContent = { Text(ip) },
+                        trailingContent = {
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(onClick = {
+                                    clipboard.setText(AnnotatedString(ip))
+                                    onAction(NetworksAction.Copy(ip))
+                                }) { Text(stringResource(Res.string.networks_copy)) }
+                                Button(onClick = { onAction(NetworksAction.UseAsBindHost(ip)) }) {
+                                    Text(stringResource(Res.string.networks_use))
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+            if (info.ipv6.isNotEmpty()) {
+                Text(stringResource(Res.string.networks_ipv6))
+                info.ipv6.forEach { ip ->
+                    ListItem(headlineContent = { Text(ip) })
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NetworksPreview() {
+    val interfaces = listOf(
+        NetworkInterfaceInfo(
+            name = "eth0",
+            isUp = true,
+            isLoopback = false,
+            supportsMulticast = true,
+            ipv4 = listOf("192.168.0.10"),
+            ipv6 = listOf("fe80::1")
+        ),
+        NetworkInterfaceInfo(
+            name = "lo",
+            isUp = true,
+            isLoopback = true,
+            supportsMulticast = false,
+            ipv4 = listOf("127.0.0.1"),
+            ipv6 = emptyList()
+        )
+    )
+    NetworksContent(result = NetworksResult(interfaces = interfaces), onAction = {}, viewModel = null)
+}

--- a/composeApp/src/desktopTest/kotlin/com/softartdev/ktlan/DesktopAppTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/softartdev/ktlan/DesktopAppTest.kt
@@ -22,7 +22,7 @@ class DesktopAppTest {
             }
         }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Scan").assertExists()
+        composeTestRule.onNodeWithText("Networks").assertExists()
         composeTestRule.onNodeWithText("Settings").assertExists()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.12.0"
 android-compileSdk = "36"
 android-minSdk = "30"
 android-targetSdk = "36"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Sat Jul 19 08:35:02 GET 2025
+#Fri Aug 01 19:47:34 GET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/shared/src/androidMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.android.kt
+++ b/shared/src/androidMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.android.kt
@@ -1,0 +1,40 @@
+package com.softartdev.ktlan.data.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.NetworkInterface
+
+actual class NetworkInterfacesProvider actual constructor(private val dispatchers: CoroutineDispatchers) {
+    actual suspend fun list(): List<NetworkInterfaceInfo> = withContext(dispatchers.io) {
+        runCatching {
+            NetworkInterface.getNetworkInterfaces().toList()
+                .sortedBy { it.index }
+                .map { ni ->
+                    val ipv4 = ni.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .map { it.hostAddress }
+                    val ipv6 = ni.inetAddresses.toList()
+                        .filterIsInstance<Inet6Address>()
+                        .map { it.hostAddress }
+                    NetworkInterfaceInfo(
+                        name = ni.name,
+                        isUp = ni.isUp,
+                        isLoopback = ni.isLoopback,
+                        supportsMulticast = ni.supportsMulticast(),
+                        ipv4 = ipv4,
+                        ipv6 = ipv6,
+                        mtu = runCatching { ni.mtu }.getOrNull(),
+                        index = runCatching { ni.index }.getOrNull()
+                    )
+                }
+        }.getOrElse { emptyList() }
+    }
+
+    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow { emit(list()) }.flowOn(dispatchers.io)
+}

--- a/shared/src/androidMain/kotlin/com/softartdev/ktlan/di/sharedModules.android.kt
+++ b/shared/src/androidMain/kotlin/com/softartdev/ktlan/di/sharedModules.android.kt
@@ -2,6 +2,7 @@ package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.data.webrtc.AndroidClientWebRTC
 import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
@@ -12,4 +13,5 @@ import org.koin.dsl.module
 actual val dataModule: Module = module {
     factoryOf(::AndroidClientWebRTC) bind ServerlessRTCClient::class
     singleOf(::SocketTransport)
+    singleOf(::NetworkInterfacesProvider)
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.kt
@@ -1,0 +1,11 @@
+package com.softartdev.ktlan.data.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.flow.Flow
+
+/** Provides a list of available network interfaces. */
+expect class NetworkInterfacesProvider(dispatchers: CoroutineDispatchers) {
+    suspend fun list(): List<NetworkInterfaceInfo>
+    fun watch(): Flow<List<NetworkInterfaceInfo>>
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/di/sharedModules.kt
@@ -2,9 +2,11 @@ package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.domain.repo.ConnectRepo
 import com.softartdev.ktlan.domain.repo.SocketRepo
+import com.softartdev.ktlan.domain.repo.NetworksRepo
 import com.softartdev.ktlan.domain.repo.ScanRepo
 import com.softartdev.ktlan.presentation.connect.ConnectViewModel
 import com.softartdev.ktlan.presentation.socket.SocketViewModel
+import com.softartdev.ktlan.presentation.networks.NetworksViewModel
 import com.softartdev.ktlan.presentation.scan.ScanViewModel
 import com.softartdev.ktlan.presentation.settings.SettingsViewModel
 import org.koin.core.module.Module
@@ -22,11 +24,13 @@ val domainModule: Module = module {
     factoryOf(::ScanRepo)
     singleOf(::ConnectRepo)
     singleOf(::SocketRepo)
+    singleOf(::NetworksRepo)
 }
 
 val presentationModule: Module = module {
     viewModelOf(::ScanViewModel)
     viewModelOf(::ConnectViewModel)
     viewModelOf(::SocketViewModel)
+    viewModelOf(::NetworksViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/NetworkInterfaceInfo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/model/NetworkInterfaceInfo.kt
@@ -1,0 +1,13 @@
+package com.softartdev.ktlan.domain.model
+
+/** Information about a network interface. */
+data class NetworkInterfaceInfo(
+    val name: String,
+    val isUp: Boolean,
+    val isLoopback: Boolean,
+    val supportsMulticast: Boolean,
+    val ipv4: List<String> = emptyList(),
+    val ipv6: List<String> = emptyList(),
+    val mtu: Int? = null,
+    val index: Int? = null,
+)

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/NetworksRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/NetworksRepo.kt
@@ -1,0 +1,32 @@
+package com.softartdev.ktlan.domain.repo
+
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+
+/** Repository providing network interface information. */
+class NetworksRepo(
+    private val provider: NetworkInterfacesProvider,
+    private val dispatchers: CoroutineDispatchers
+) {
+    suspend fun listInterfaces(): List<NetworkInterfaceInfo> = provider.list()
+
+    suspend fun guessLocalIPv4(): String? {
+        val interfaces = provider.list()
+        val filtered = interfaces.filter { it.isUp && !it.isLoopback }
+        val addresses = filtered.flatMap { it.ipv4 }
+        val preferred = addresses.firstOrNull { it.isPrivateIpv4() }
+        return preferred ?: addresses.firstOrNull()
+    }
+}
+
+private fun String.isPrivateIpv4(): Boolean {
+    if (startsWith("10.")) return true
+    if (startsWith("192.168.")) return true
+    if (startsWith("172.")) {
+        val part = split(".").getOrNull(1)?.toIntOrNull()
+        if (part != null && part in 16..31) return true
+    }
+    return false
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/NetworksRepo.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/domain/repo/NetworksRepo.kt
@@ -6,13 +6,13 @@ import com.softartdev.ktlan.domain.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
 
 /** Repository providing network interface information. */
-class NetworksRepo(
+open class NetworksRepo(
     private val provider: NetworkInterfacesProvider,
     private val dispatchers: CoroutineDispatchers
 ) {
-    suspend fun listInterfaces(): List<NetworkInterfaceInfo> = provider.list()
+    open suspend fun listInterfaces(): List<NetworkInterfaceInfo> = provider.list()
 
-    suspend fun guessLocalIPv4(): String? {
+    open suspend fun guessLocalIPv4(): String? {
         val interfaces = provider.list()
         val filtered = interfaces.filter { it.isUp && !it.isLoopback }
         val addresses = filtered.flatMap { it.ipv4 }

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/navigation/AppNavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/navigation/AppNavGraph.kt
@@ -7,7 +7,7 @@ sealed interface AppNavGraph {
     sealed interface BottomTab : AppNavGraph {
 
         @Serializable
-        data object Scan : BottomTab
+        data object Networks : BottomTab
 
         @Serializable
         data object Connect : BottomTab

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/networks/NetworksResult.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/networks/NetworksResult.kt
@@ -1,0 +1,19 @@
+package com.softartdev.ktlan.presentation.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+
+/** UI state for Networks screen. */
+data class NetworksResult(
+    val loading: Boolean = false,
+    val interfaces: List<NetworkInterfaceInfo> = emptyList(),
+    val error: String? = null,
+    val selectedIp: String? = null,
+    val showAll: Boolean = false,
+)
+
+sealed interface NetworksAction {
+    data object Refresh : NetworksAction
+    data class ToggleShowAll(val show: Boolean) : NetworksAction
+    data class Copy(val address: String) : NetworksAction
+    data class UseAsBindHost(val address: String) : NetworksAction
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/networks/NetworksViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/networks/NetworksViewModel.kt
@@ -1,0 +1,53 @@
+package com.softartdev.ktlan.presentation.networks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.softartdev.ktlan.domain.repo.NetworksRepo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** ViewModel for listing network interfaces. */
+class NetworksViewModel(
+    private val repo: NetworksRepo,
+    private val dispatchers: CoroutineDispatchers
+) : ViewModel() {
+
+    private val state = MutableStateFlow(NetworksResult())
+    val stateFlow: StateFlow<NetworksResult> = state
+    private var launched = false
+
+    fun launch() {
+        if (launched) return
+        launched = true
+        onAction(NetworksAction.Refresh)
+    }
+
+    fun onAction(action: NetworksAction) {
+        when (action) {
+            is NetworksAction.Refresh -> viewModelScope.launch {
+                state.update { it.copy(loading = true, error = null) }
+                runCatching { repo.listInterfaces() }
+                    .onSuccess { list ->
+                        val filtered = if (state.value.showAll) list else list.filter { it.isUp && !it.isLoopback }
+                        state.update { it.copy(loading = false, interfaces = filtered) }
+                    }
+                    .onFailure { e ->
+                        Napier.e("Failed to list interfaces", e)
+                        state.update { it.copy(loading = false, error = e.message) }
+                    }
+            }
+            is NetworksAction.ToggleShowAll -> {
+                state.update { it.copy(showAll = action.show) }
+                onAction(NetworksAction.Refresh)
+            }
+            is NetworksAction.Copy -> state.update { it.copy(selectedIp = action.address) }
+            is NetworksAction.UseAsBindHost -> state.update { it.copy(selectedIp = action.address) }
+        }
+    }
+
+    suspend fun guessLocalIp(): String? = repo.guessLocalIPv4()
+}

--- a/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModel.kt
@@ -6,6 +6,7 @@ import com.softartdev.ktlan.data.socket.SocketEndpoint
 import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.domain.model.ChatMessage
 import com.softartdev.ktlan.domain.repo.SocketRepo
+import com.softartdev.ktlan.domain.repo.NetworksRepo
 import com.softartdev.ktlan.presentation.navigation.AppNavGraph
 import com.softartdev.ktlan.presentation.navigation.Router
 import io.github.aakira.napier.Napier
@@ -21,6 +22,7 @@ class SocketViewModel(
     private val router: Router,
     private val repo: SocketRepo,
     private val transport: SocketTransport,
+    private val networksRepo: NetworksRepo,
 ) : ViewModel() {
     private val state = MutableStateFlow(SocketResult())
     val stateFlow: StateFlow<SocketResult> = state
@@ -39,7 +41,7 @@ class SocketViewModel(
     }
 
     suspend fun updateLocalIp() {
-        val ip = repo.getLocalIp()
+        val ip = networksRepo.guessLocalIPv4() ?: repo.getLocalIp()
         state.update { it.copy(bindHost = ip) }
     }
 

--- a/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/softartdev/ktlan/presentation/socket/SocketViewModelTest.kt
@@ -2,8 +2,11 @@
 
 package com.softartdev.ktlan.presentation.socket
 
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
 import com.softartdev.ktlan.data.socket.SocketTransport
 import com.softartdev.ktlan.domain.model.ChatMessage
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.repo.NetworksRepo
 import com.softartdev.ktlan.domain.repo.SocketRepo
 import com.softartdev.ktlan.domain.util.CoroutineDispatchers
 import com.softartdev.ktlan.presentation.navigation.Router
@@ -41,6 +44,14 @@ private class FakeRouter : Router {
     override fun popBackStack() = false
 }
 
+private class FakeNetworkRepo(dispatchers: CoroutineDispatchers) : NetworksRepo(
+    provider = NetworkInterfacesProvider(dispatchers),
+    dispatchers = dispatchers
+) {
+    override suspend fun listInterfaces(): List<NetworkInterfaceInfo> = emptyList()
+    override suspend fun guessLocalIPv4(): String? = "192.168.0.1"
+}
+
 class SocketViewModelTest {
     private var testDispatchers: CoroutineDispatchersStub? = null
     private var repo: FakeRepo? = null
@@ -51,7 +62,8 @@ class SocketViewModelTest {
         Napier.base(PrintAntilog())
         testDispatchers = CoroutineDispatchersStub()
         repo = FakeRepo(testDispatchers!!)
-        vm = SocketViewModel(FakeRouter(), repo!!, SocketTransport(testDispatchers!!))
+        val networksRepo = FakeNetworkRepo(testDispatchers!!)
+        vm = SocketViewModel(FakeRouter(), repo!!, SocketTransport(testDispatchers!!), networksRepo)
     }
 
     @AfterTest

--- a/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.ios.kt
+++ b/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.ios.kt
@@ -1,18 +1,29 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.softartdev.ktlan.data.networks
 
 import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
 import com.softartdev.ktlan.domain.util.CoroutineDispatchers
 import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.toKString
+import kotlinx.cinterop.value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import platform.darwin.freeifaddrs
+import platform.darwin.getifaddrs
+import platform.darwin.ifaddrs
+import platform.darwin.inet_ntop
 import platform.posix.AF_INET
 import platform.posix.AF_INET6
 import platform.posix.IFF_LOOPBACK
@@ -20,10 +31,6 @@ import platform.posix.IFF_MULTICAST
 import platform.posix.IFF_UP
 import platform.posix.INET6_ADDRSTRLEN
 import platform.posix.INET_ADDRSTRLEN
-import platform.posix.getifaddrs
-import platform.posix.ifaddrs
-import platform.posix.inet_ntop
-import platform.posix.freeifaddrs
 import platform.posix.sockaddr_in
 import platform.posix.sockaddr_in6
 
@@ -33,16 +40,16 @@ actual class NetworkInterfacesProvider actual constructor(private val dispatcher
             val ifap = alloc<CPointerVar<ifaddrs>>()
             val result = mutableMapOf<String, MutableInterfaceData>()
             if (getifaddrs(ifap.ptr) == 0) {
-                var ptr = ifap.value
+                var ptr: CPointer<ifaddrs>? = ifap.value
                 while (ptr != null) {
                     val ifa = ptr.pointed
                     val name = ifa.ifa_name?.toKString() ?: ""
                     val flags = ifa.ifa_flags.toInt()
                     val data = result.getOrPut(name) {
                         MutableInterfaceData(
-                            isUp = flags and IFF_UP.toInt() != 0,
-                            isLoopback = flags and IFF_LOOPBACK.toInt() != 0,
-                            supportsMulticast = flags and IFF_MULTICAST.toInt() != 0
+                            isUp = flags and IFF_UP != 0,
+                            isLoopback = flags and IFF_LOOPBACK != 0,
+                            supportsMulticast = flags and IFF_MULTICAST != 0
                         )
                     }
                     val addr = ifa.ifa_addr
@@ -50,14 +57,14 @@ actual class NetworkInterfacesProvider actual constructor(private val dispatcher
                         when (addr.pointed.sa_family.toInt()) {
                             AF_INET -> {
                                 val buf = allocArray<ByteVar>(INET_ADDRSTRLEN)
-                                val sa = addr.reinterpret<sockaddr_in>()
-                                inet_ntop(AF_INET, sa.ptr.pointed.sin_addr.ptr, buf, INET_ADDRSTRLEN.toULong())
+                                val sa: CPointer<sockaddr_in> = addr.reinterpret<sockaddr_in>()
+                                inet_ntop(AF_INET, sa.pointed.sin_addr.ptr, buf, INET_ADDRSTRLEN.toUInt())
                                 data.ipv4 += buf.toKString()
                             }
                             AF_INET6 -> {
                                 val buf = allocArray<ByteVar>(INET6_ADDRSTRLEN)
                                 val sa = addr.reinterpret<sockaddr_in6>()
-                                inet_ntop(AF_INET6, sa.ptr.pointed.sin6_addr.ptr, buf, INET6_ADDRSTRLEN.toULong())
+                                inet_ntop(AF_INET6, sa.pointed.sin6_addr.ptr, buf, INET6_ADDRSTRLEN.toUInt())
                                 data.ipv6 += buf.toKString()
                             }
                         }

--- a/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.ios.kt
+++ b/shared/src/iosMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.ios.kt
@@ -1,0 +1,91 @@
+package com.softartdev.ktlan.data.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.toKString
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import platform.posix.AF_INET
+import platform.posix.AF_INET6
+import platform.posix.IFF_LOOPBACK
+import platform.posix.IFF_MULTICAST
+import platform.posix.IFF_UP
+import platform.posix.INET6_ADDRSTRLEN
+import platform.posix.INET_ADDRSTRLEN
+import platform.posix.getifaddrs
+import platform.posix.ifaddrs
+import platform.posix.inet_ntop
+import platform.posix.freeifaddrs
+import platform.posix.sockaddr_in
+import platform.posix.sockaddr_in6
+
+actual class NetworkInterfacesProvider actual constructor(private val dispatchers: CoroutineDispatchers) {
+    actual suspend fun list(): List<NetworkInterfaceInfo> = withContext(dispatchers.io) {
+        memScoped {
+            val ifap = alloc<CPointerVar<ifaddrs>>()
+            val result = mutableMapOf<String, MutableInterfaceData>()
+            if (getifaddrs(ifap.ptr) == 0) {
+                var ptr = ifap.value
+                while (ptr != null) {
+                    val ifa = ptr.pointed
+                    val name = ifa.ifa_name?.toKString() ?: ""
+                    val flags = ifa.ifa_flags.toInt()
+                    val data = result.getOrPut(name) {
+                        MutableInterfaceData(
+                            isUp = flags and IFF_UP.toInt() != 0,
+                            isLoopback = flags and IFF_LOOPBACK.toInt() != 0,
+                            supportsMulticast = flags and IFF_MULTICAST.toInt() != 0
+                        )
+                    }
+                    val addr = ifa.ifa_addr
+                    if (addr != null) {
+                        when (addr.pointed.sa_family.toInt()) {
+                            AF_INET -> {
+                                val buf = allocArray<ByteVar>(INET_ADDRSTRLEN)
+                                val sa = addr.reinterpret<sockaddr_in>()
+                                inet_ntop(AF_INET, sa.ptr.pointed.sin_addr.ptr, buf, INET_ADDRSTRLEN.toULong())
+                                data.ipv4 += buf.toKString()
+                            }
+                            AF_INET6 -> {
+                                val buf = allocArray<ByteVar>(INET6_ADDRSTRLEN)
+                                val sa = addr.reinterpret<sockaddr_in6>()
+                                inet_ntop(AF_INET6, sa.ptr.pointed.sin6_addr.ptr, buf, INET6_ADDRSTRLEN.toULong())
+                                data.ipv6 += buf.toKString()
+                            }
+                        }
+                    }
+                    ptr = ifa.ifa_next
+                }
+                freeifaddrs(ifap.value)
+            }
+            result.map { (name, d) ->
+                NetworkInterfaceInfo(
+                    name = name,
+                    isUp = d.isUp,
+                    isLoopback = d.isLoopback,
+                    supportsMulticast = d.supportsMulticast,
+                    ipv4 = d.ipv4,
+                    ipv6 = d.ipv6
+                )
+            }
+        }
+    }
+
+    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow { emit(list()) }.flowOn(dispatchers.io)
+}
+
+private data class MutableInterfaceData(
+    val isUp: Boolean,
+    val isLoopback: Boolean,
+    val supportsMulticast: Boolean,
+    val ipv4: MutableList<String> = mutableListOf(),
+    val ipv6: MutableList<String> = mutableListOf()
+)

--- a/shared/src/iosMain/kotlin/com/softartdev/ktlan/di/sharedModules.ios.kt
+++ b/shared/src/iosMain/kotlin/com/softartdev/ktlan/di/sharedModules.ios.kt
@@ -1,6 +1,7 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
 import com.softartdev.ktlan.data.webrtc.IOSClientWebRTC
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.Module
@@ -12,4 +13,5 @@ import org.koin.dsl.module
 actual val dataModule: Module = module {
     factoryOf(::IOSClientWebRTC) bind ServerlessRTCClient::class
     singleOf(::SocketTransport)
+    singleOf(::NetworkInterfacesProvider)
 }

--- a/shared/src/jvmMain/java/com/softartdev/ktlan/di/sharedModules.jvm.kt
+++ b/shared/src/jvmMain/java/com/softartdev/ktlan/di/sharedModules.jvm.kt
@@ -1,6 +1,7 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
 import com.softartdev.ktlan.data.webrtc.JvmClientWebRTC
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import org.koin.core.module.dsl.factoryOf
@@ -11,4 +12,5 @@ import org.koin.dsl.module
 actual val dataModule: org.koin.core.module.Module = module {
     factoryOf(::JvmClientWebRTC) bind ServerlessRTCClient::class
     singleOf(::SocketTransport)
+    singleOf(::NetworkInterfacesProvider)
 }

--- a/shared/src/jvmMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.jvm.kt
@@ -1,0 +1,40 @@
+package com.softartdev.ktlan.data.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.NetworkInterface
+
+actual class NetworkInterfacesProvider actual constructor(private val dispatchers: CoroutineDispatchers) {
+    actual suspend fun list(): List<NetworkInterfaceInfo> = withContext(dispatchers.io) {
+        runCatching {
+            NetworkInterface.getNetworkInterfaces().toList()
+                .sortedBy { it.index }
+                .map { ni ->
+                    val ipv4 = ni.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .map { it.hostAddress }
+                    val ipv6 = ni.inetAddresses.toList()
+                        .filterIsInstance<Inet6Address>()
+                        .map { it.hostAddress }
+                    NetworkInterfaceInfo(
+                        name = ni.name,
+                        isUp = ni.isUp,
+                        isLoopback = ni.isLoopback,
+                        supportsMulticast = ni.supportsMulticast(),
+                        ipv4 = ipv4,
+                        ipv6 = ipv6,
+                        mtu = runCatching { ni.mtu }.getOrNull(),
+                        index = runCatching { ni.index }.getOrNull()
+                    )
+                }
+        }.getOrElse { emptyList() }
+    }
+
+    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow { emit(list()) }.flowOn(dispatchers.io)
+}

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.wasmJs.kt
@@ -1,0 +1,12 @@
+package com.softartdev.ktlan.data.networks
+
+import com.softartdev.ktlan.domain.model.NetworkInterfaceInfo
+import com.softartdev.ktlan.domain.util.CoroutineDispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+actual class NetworkInterfacesProvider actual constructor(private val dispatchers: CoroutineDispatchers) {
+    actual suspend fun list(): List<NetworkInterfaceInfo> = emptyList()
+    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow { emit(emptyList()) }.flowOn(dispatchers.io)
+}

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/networks/NetworkInterfacesProvider.wasmJs.kt
@@ -8,5 +8,5 @@ import kotlinx.coroutines.flow.flowOn
 
 actual class NetworkInterfacesProvider actual constructor(private val dispatchers: CoroutineDispatchers) {
     actual suspend fun list(): List<NetworkInterfaceInfo> = emptyList()
-    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow { emit(emptyList()) }.flowOn(dispatchers.io)
+    actual fun watch(): Flow<List<NetworkInterfaceInfo>> = flow<List<NetworkInterfaceInfo>> { emit(emptyList()) }.flowOn(dispatchers.io)
 }

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/di/sharedModules.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/di/sharedModules.wasmJs.kt
@@ -1,6 +1,7 @@
 package com.softartdev.ktlan.di
 
 import com.softartdev.ktlan.data.socket.SocketTransport
+import com.softartdev.ktlan.data.networks.NetworkInterfacesProvider
 import com.softartdev.ktlan.data.webrtc.ServerlessRTCClient
 import com.softartdev.ktlan.data.webrtc.WasmJsClientWebRTC
 import org.koin.core.module.Module
@@ -12,4 +13,5 @@ import org.koin.dsl.module
 actual val dataModule: Module = module {
     factoryOf(::WasmJsClientWebRTC) bind ServerlessRTCClient::class
     singleOf(::SocketTransport)
+    singleOf(::NetworkInterfacesProvider)
 }


### PR DESCRIPTION
## Summary
- add strings for Networks screen
- implement `NetworkInterfacesProvider` with expect/actual to list interfaces
- add `NetworksRepo` and corresponding viewmodel
- create Networks composable screen
- replace Scan tab with Networks tab in bottom navigation
- prefill bind host using detected local IPv4

## Testing
- `./gradlew :shared:compileKotlinJvm --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6889c688e82483308deeb79ddbcca740