### PR TITLE
Implement wasm WebRTC client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ qrose = "1.0.1"
 kscan = "0.1.0-beta08"
 camera-compose-permission = "1.6.10.1"
 json = "20250517"
+kotlinx-browser = "0.3"
+serialization-json = "1.9.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -73,6 +75,8 @@ qrose = { module = "io.github.alexzhirkevich:qrose", version.ref = "qrose" }
 kscan = { module = "io.github.ismai117:KScan", version.ref = "kscan" }
 camera-compose-permission = { module = "in.procyk.compose:camera-permission", version.ref = "camera-compose-permission" }
 json = { module = "org.json:json", version.ref = "json" }
+kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization-json" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -77,6 +77,11 @@ kotlin {
             implementation(dependencies.variantOf(libs.webrtc.java) { classifier("linux-aarch32") })
             implementation(libs.json)
         }
+        wasmJsMain.dependencies {
+            implementation(libs.kotlinx.browser)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(npm("webrtc-adapter", "9.0.1"))
+        }
     }
     cocoapods {
         name = "SharedCocoaPod"

--- a/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/webrtc/WasmJsClientWebRTC.kt
+++ b/shared/src/wasmJsMain/kotlin/com/softartdev/ktlan/data/webrtc/WasmJsClientWebRTC.kt
@@ -1,10 +1,205 @@
 package com.softartdev.ktlan.data.webrtc
 
-class WasmJsClientWebRTC() : ServerlessRTCClient() {
-    override fun processOffer(sdpJSON: String) = console.d("processOffer()") // TODO
-    override fun processAnswer(sdpJSON: String) = console.d("processAnswer()") // TODO
-    override fun makeOffer() = console.d("makeOffer()") // TODO
-    override fun sendMessage(message: String) = console.d("sendMessage()") // TODO
-    override fun makeDataChannel() = console.d("makeDataChannel()") // TODO
-    override fun destroy() = console.d("destroy()") // TODO
+import kotlin.js.Promise
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.js.JsAny
+import kotlin.js.JsArray
+
+@JsFun("() => ({iceServers: [{urls: 'stun:stun.l.google.com:19302'}]})")
+private external fun defaultRtcConfig(): RTCConfiguration
+
+@JsFun("(type, sdp) => ({type: type, sdp: sdp})")
+private external fun createSdp(type: String, sdp: String): RTCSessionDescriptionInit
+
+@JsFun("() => ({})")
+private external fun emptyDataChannelInit(): RTCDataChannelInit
+
+/** External declarations for WebRTC browser API */
+external class RTCPeerConnection(configuration: RTCConfiguration = definedExternally) : JsAny {
+    var onicecandidate: ((RTCPeerConnectionIceEvent) -> Unit)?
+    var onicegatheringstatechange: (() -> Unit)?
+    var ondatachannel: ((RTCDataChannelEvent) -> Unit)?
+    val localDescription: RTCSessionDescription?
+    val remoteDescription: RTCSessionDescription?
+    val iceGatheringState: String
+    fun createOffer(): Promise<RTCSessionDescriptionInit>
+    fun createAnswer(): Promise<RTCSessionDescriptionInit>
+    fun setLocalDescription(desc: RTCSessionDescriptionInit): Promise<JsAny?>
+    fun setRemoteDescription(desc: RTCSessionDescriptionInit): Promise<JsAny?>
+    fun createDataChannel(label: String, options: RTCDataChannelInit = definedExternally): RTCDataChannel
+    fun close()
 }
+external interface RTCConfiguration : JsAny { var iceServers: JsArray<RTCIceServer>? }
+external interface RTCIceServer : JsAny { var urls: String }
+
+external class RTCPeerConnectionIceEvent : JsAny { val candidate: RTCIceCandidate? }
+external class RTCIceCandidate : JsAny { val candidate: String? }
+
+external class RTCDataChannelEvent : JsAny { val channel: RTCDataChannel }
+
+external class RTCDataChannel : JsAny {
+    var onmessage: ((MessageEvent) -> Unit)?
+    var onopen: (() -> Unit)?
+    var onclose: (() -> Unit)?
+    var onbufferedamountlow: (() -> Unit)?
+    val bufferedAmount: Int
+    fun send(data: String)
+    fun close()
+}
+
+external interface RTCDataChannelInit : JsAny
+
+external class RTCSessionDescription : JsAny { val type: String; val sdp: String }
+external interface RTCSessionDescriptionInit : JsAny { var type: String; var sdp: String }
+
+external class MessageEvent : JsAny { val data: JsAny? }
+
+/**
+ * WebRTC client implementation for wasm/js platform using browser WebRTC APIs.
+ */
+class WasmJsClientWebRTC : ServerlessRTCClient() {
+    private var pc: RTCPeerConnection? = null
+    private var channel: RTCDataChannel? = null
+
+    private fun sessionDescriptionToJSON(desc: RTCSessionDescription): String =
+        Json.encodeToString(
+            buildJsonObject {
+                put(JSON_TYPE, desc.type)
+                put(JSON_SDP, desc.sdp)
+            }
+        )
+
+    override fun processOffer(sdpJSON: String) {
+        try {
+            val jsonObj = Json.parseToJsonElement(sdpJSON).jsonObject
+            val type = jsonObj[JSON_TYPE]?.jsonPrimitive?.content
+            val sdp = jsonObj[JSON_SDP]?.jsonPrimitive?.content
+            p2pState = P2pState.CREATING_ANSWER
+            if (type == "offer" && sdp != null) {
+                val peer = RTCPeerConnection(defaultRtcConfig())
+                pc = peer
+                peer.onicecandidate = { event ->
+                    console.d("ice candidate:{${event.candidate?.candidate}}")
+                }
+                peer.onicegatheringstatechange = {
+                    if (peer.iceGatheringState == "complete") {
+                        console.printf("Here is your answer:")
+                        peer.localDescription?.let { console.greenf(sessionDescriptionToJSON(it)) }
+                        p2pState = P2pState.WAITING_TO_CONNECT
+                    }
+                }
+                peer.ondatachannel = { evt ->
+                    val dc = evt.channel
+                    channel = dc
+                    registerDataChannel(dc)
+                }
+                peer.setRemoteDescription(createSdp(type, sdp)).then {
+                    peer.createAnswer().then { answer ->
+                        peer.setLocalDescription(answer)
+                    }
+                }
+            } else {
+                console.redf("Invalid or unsupported offer.")
+                p2pState = P2pState.WAITING_FOR_OFFER
+            }
+        } catch (t: Throwable) {
+            console.redf("bad json")
+            p2pState = P2pState.WAITING_FOR_OFFER
+        }
+    }
+
+    override fun processAnswer(sdpJSON: String) {
+        try {
+            val jsonObj = Json.parseToJsonElement(sdpJSON).jsonObject
+            val type = jsonObj[JSON_TYPE]?.jsonPrimitive?.content
+            val sdp = jsonObj[JSON_SDP]?.jsonPrimitive?.content
+            p2pState = P2pState.WAITING_TO_CONNECT
+            val peer = pc
+            if (peer != null && type == "answer" && sdp != null) {
+                peer.setRemoteDescription(createSdp(type, sdp))
+            } else {
+                console.redf("Invalid or unsupported answer.")
+                p2pState = P2pState.WAITING_FOR_ANSWER
+            }
+        } catch (t: Throwable) {
+            console.redf("bad json")
+            p2pState = P2pState.WAITING_FOR_ANSWER
+        }
+    }
+
+    override fun makeOffer() {
+        p2pState = P2pState.CREATING_OFFER
+        val peer = RTCPeerConnection(defaultRtcConfig())
+        pc = peer
+        peer.onicecandidate = { event ->
+            console.d("ice candidate:{${event.candidate?.candidate}}")
+        }
+        peer.onicegatheringstatechange = {
+            if (peer.iceGatheringState == "complete") {
+                console.printf("Your offer is:")
+                peer.localDescription?.let { console.greenf(sessionDescriptionToJSON(it)) }
+                p2pState = P2pState.WAITING_FOR_ANSWER
+            }
+        }
+        makeDataChannel()
+        peer.createOffer().then { offer ->
+            peer.setLocalDescription(offer)
+        }
+    }
+
+    override fun sendMessage(message: String) {
+        val dc = channel
+        if (dc != null && p2pState == P2pState.CHAT_ESTABLISHED) {
+            val data = Json.encodeToString(buildJsonObject { put(JSON_MESSAGE, message) })
+            dc.send(data)
+        } else {
+            console.redf("Error. Chat is not established.")
+        }
+    }
+
+    override fun makeDataChannel() {
+        val peer = pc ?: return
+        val dc = peer.createDataChannel("test", emptyDataChannelInit())
+        channel = dc
+        registerDataChannel(dc)
+    }
+
+    private fun registerDataChannel(dc: RTCDataChannel) {
+        dc.onmessage = { event ->
+            val dataStr = event.data?.toString() ?: ""
+            val msg = try {
+                Json.parseToJsonElement(dataStr).jsonObject[JSON_MESSAGE]?.jsonPrimitive?.content
+            } catch (_: Throwable) {
+                null
+            }
+            if (msg != null) {
+                console.bluef(">$msg")
+            } else {
+                console.redf("Malformed message received")
+            }
+        }
+        dc.onopen = {
+            p2pState = P2pState.CHAT_ESTABLISHED
+            console.bluef("Chat established.")
+            val remoteAddress = pc?.remoteDescription?.sdp ?: "unknown"
+            console.printf("Connected to remote peer: $remoteAddress")
+        }
+        dc.onclose = {
+            p2pState = P2pState.CHAT_ENDED
+            console.redf("Chat ended.")
+        }
+        dc.onbufferedamountlow = {
+            console.d("channel buffered amount changed:${dc.bufferedAmount}")
+        }
+    }
+
+    override fun destroy() {
+        channel?.close()
+        pc?.close()
+    }
+}
+


### PR DESCRIPTION
## Summary
- define WebRTC browser bindings and STUN configuration for wasm/js
- implement offer/answer handling, data channels, and message exchange in wasm WebRTC client

## Testing
- `./gradlew :shared:compileKotlinWasmJs`


------
https://chatgpt.com/codex/tasks/task_e_6897b33ca0348330bb3fefb5eca6a474